### PR TITLE
update cmake version according to rapids-cmake change

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.20.1)
+cmake_minimum_required(VERSION 3.23.1)
 
 include(./fetch_rapids.cmake)
 include(rapids-cmake)

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,3 +27,4 @@ RUN cd dgl && \
 ENV USE_TORCH_ALLOC 1
 
 RUN pip3 install torchmetrics
+RUN conda install -y 'cmake>=3.23.1'


### PR DESCRIPTION
As repids-cmake has updated cmake minimum version required last week, WholeGraph needs to update cmake minimum version accordingly.