### PR TITLE
Update to clang 16.0.6.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
             scripts
           )
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v16.0.0
+    rev: v16.0.6
     hooks:
       - id: clang-format
         exclude: |


### PR DESCRIPTION
This PR updates wholegraph to use clang 16.0.6. The previous version has some minor formatting issues affecting several RAPIDS repos.