### PR TITLE
Fix dependencies on librmm and libraft.

### DIFF
--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -11,7 +11,7 @@ dependencies:
 - c-compiler
 - clang-tools=16.0.0
 - clangxx=16.0.0
-- cmake>=3.23.1,!=3.25.0
+- cmake>=3.26.4
 - cuda-nvtx=11.8
 - cudatoolkit=11.8
 - cudnn=8.4

--- a/conda/environments/all_cuda-120_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-120_arch-x86_64.yaml
@@ -11,7 +11,7 @@ dependencies:
 - c-compiler
 - clang-tools=16.0.0
 - clangxx=16.0.0
-- cmake>=3.23.1,!=3.25.0
+- cmake>=3.26.4
 - cuda-cudart-dev
 - cuda-nvcc
 - cuda-nvtx

--- a/conda/recipes/libwholegraph/meta.yaml
+++ b/conda/recipes/libwholegraph/meta.yaml
@@ -94,8 +94,6 @@ outputs:
         - cudatoolkit
         {% endif %}
         - libraft ={{ minor_version }}
-        - libraft-headers ={{ minor_version }}
-        - librmm ={{ minor_version }}
         - nccl {{ nccl_version }}
     about:
       home: https://rapids.ai/

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -67,13 +67,15 @@ dependencies:
       - output_types: conda
         packages:
           - c-compiler
-          - cmake>=3.23.1,!=3.25.0
+          - cmake>=3.26.4
           - cudnn=8.4
-          - nccl
           - cxx-compiler
-          - nanobind>=0.2.0
           - cython
           - doxygen=1.8.20
+          - libraft-headers==23.12.*
+          - librmm==23.12.*
+          - nanobind>=0.2.0
+          - nccl
           - scikit-build
     specific:
       - output_types: conda
@@ -163,9 +165,7 @@ dependencies:
   run:
     common:
       - output_types: [conda, requirements]
-        packages:
-          - libraft-headers==23.12.*
-          - librmm==23.12.*
+        packages: []
   test_cpp:
     common:
       - output_types: [conda, requirements]


### PR DESCRIPTION
The package currently has runtime dependencies on librmm and libraft-headers. However, these packages are header-only, so it's only sensible to require them at build time. This PR removes librmm and libraft-headers from the runtime dependencies of libwholegraph.

This PR is needed to fix the conda environments in [unified devcontainers](https://github.com/rapidsai/devcontainers).