### PR TITLE
change pytorch cu121 to stable to fix ci

### DIFF
--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -15,7 +15,7 @@ python -m pip install $(echo ./dist/pylibwholegraph*.whl)
 PKG_CUDA_VER="$(echo ${CUDA_VERSION} | cut -d '.' -f1,2 | tr -d '.')"
 PKG_CUDA_VER_MAJOR=${PKG_CUDA_VER:0:2}
 if [[ "${PKG_CUDA_VER_MAJOR}" == "12" ]]; then
-  INDEX_URL="https://download.pytorch.org/whl/nightly/cu121"
+  INDEX_URL="https://download.pytorch.org/whl/cu121"
 else
   INDEX_URL="https://download.pytorch.org/whl/cu${PKG_CUDA_VER}"
 fi


### PR DESCRIPTION
This PR is to fix wheel-test in CI.
@chuangz0 also helped find the root course:
Pytorch cu121 nightly seems will initialize CUDA at import time, which will cause later forked subprocess failed in CUDA calls.
Fix:
Change pytorch cu121 back to stable.