### PR TITLE
Forward-merge branch-23.12 to branch-24.02

### DIFF
--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -15,7 +15,7 @@ python -m pip install $(echo ./dist/pylibwholegraph*.whl)
 PKG_CUDA_VER="$(echo ${CUDA_VERSION} | cut -d '.' -f1,2 | tr -d '.')"
 PKG_CUDA_VER_MAJOR=${PKG_CUDA_VER:0:2}
 if [[ "${PKG_CUDA_VER_MAJOR}" == "12" ]]; then
-  INDEX_URL="https://download.pytorch.org/whl/nightly/cu121"
+  INDEX_URL="https://download.pytorch.org/whl/cu121"
 else
   INDEX_URL="https://download.pytorch.org/whl/cu${PKG_CUDA_VER}"
 fi


### PR DESCRIPTION
Forward-merge triggered by push to `branch-23.12` that creates a PR to keep `branch-24.02` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.