### PR TITLE
Align versions for cudnn, clang-tools, cython, and doxygen with the rest of RAPIDS.

### DIFF
--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -9,15 +9,15 @@ channels:
 dependencies:
 - breathe
 - c-compiler
-- clang-tools=16.0.0
-- clangxx=16.0.0
+- clang-tools==16.0.6
+- clangxx==16.0.6
 - cmake>=3.26.4
 - cuda-nvtx=11.8
 - cudatoolkit=11.8
-- cudnn=8.4
+- cudnn=8.8
 - cxx-compiler
-- cython
-- doxygen=1.8.20
+- cython>=3.0.0
+- doxygen==1.9.1
 - gcc_linux-64=11.*
 - gitpython
 - graphviz

--- a/conda/environments/all_cuda-120_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-120_arch-x86_64.yaml
@@ -9,17 +9,17 @@ channels:
 dependencies:
 - breathe
 - c-compiler
-- clang-tools=16.0.0
-- clangxx=16.0.0
+- clang-tools==16.0.6
+- clangxx==16.0.6
 - cmake>=3.26.4
 - cuda-cudart-dev
 - cuda-nvcc
 - cuda-nvtx
 - cuda-version=12.0
-- cudnn=8.4
+- cudnn=8.8
 - cxx-compiler
-- cython
-- doxygen=1.8.20
+- cython>=3.0.0
+- doxygen==1.9.1
 - gcc_linux-64=11.*
 - gitpython
 - graphviz

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -68,10 +68,10 @@ dependencies:
         packages:
           - c-compiler
           - cmake>=3.26.4
-          - cudnn=8.4
+          - cudnn=8.8
           - cxx-compiler
-          - cython
-          - doxygen=1.8.20
+          - cython>=3.0.0
+          - &doxygen doxygen==1.9.1
           - libraft-headers==24.2.*
           - librmm==24.2.*
           - nanobind>=0.2.0
@@ -252,7 +252,7 @@ dependencies:
       - output_types: [conda, requirements]
         packages:
           - breathe
-          - doxygen=1.8.20
+          - *doxygen
           - graphviz
           - ipython
           - ipykernel
@@ -274,15 +274,15 @@ dependencies:
     common:
       - output_types: [conda, requirements]
         packages:
-          - clangxx=16.0.0
-          - clang-tools=16.0.0
+          - clangxx==16.0.6
+          - clang-tools==16.0.6
           - gitpython
   python_build_wheel:
     common:
       - output_types: [pyproject]
         packages:
           - cmake>=3.26.4
-          - cython>=0.29,<0.30
+          - cython>=3.0.0
           - ninja
           - setuptools
           - scikit-build>=0.13.1

--- a/python/pylibwholegraph/pyproject.toml
+++ b/python/pylibwholegraph/pyproject.toml
@@ -15,7 +15,7 @@
 [build-system]
 requires = [
     "cmake>=3.26.4",
-    "cython>=0.29,<0.30",
+    "cython>=3.0.0",
     "ninja",
     "scikit-build>=0.13.1",
     "setuptools",


### PR DESCRIPTION
This PR aligns versions for wholegraph dependencies with versions used by other RAPIDS packages. This is needed for devcontainers, to make the unified RAPIDS conda environment solvable. See https://github.com/rapidsai/devcontainers/pull/191.