### PR TITLE
refactor CUDA versions in dependencies.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,7 @@ repos:
         pass_filenames: false
         additional_dependencies: [gitpython]
   - repo: https://github.com/rapidsai/dependency-file-generator
-    rev: v1.5.1
+    rev: v1.8.0
     hooks:
       - id: rapids-dependency-file-generator
         args: ["--clean"]

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -14,7 +14,7 @@ dependencies:
 - cmake>=3.26.4
 - cuda-nvtx=11.8
 - cuda-version=11.8
-- cudatoolkit=11.8
+- cudatoolkit
 - cudnn=8.8
 - cxx-compiler
 - cython>=3.0.0

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -13,6 +13,7 @@ dependencies:
 - clangxx==16.0.6
 - cmake>=3.26.4
 - cuda-nvtx=11.8
+- cuda-version=11.8
 - cudatoolkit=11.8
 - cudnn=8.8
 - cxx-compiler

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -144,22 +144,22 @@ dependencies:
           - matrix:
               cuda: "11.2"
             packages:
-              - cudatoolkit=11.2
+              - cudatoolkit
               - cuda-nvtx=11.4 # oldest available
           - matrix:
               cuda: "11.4"
             packages:
-              - cudatoolkit=11.4
+              - cudatoolkit
               - cuda-nvtx=11.4 # oldest available
           - matrix:
               cuda: "11.5"
             packages:
-              - cudatoolkit=11.5
+              - cudatoolkit
               - cuda-nvtx=11.5
           - matrix:
               cuda: "11.8"
             packages:
-              - cudatoolkit=11.8
+              - cudatoolkit
               - cuda-nvtx=11.8
           - matrix:
               cuda: "12.*"

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -33,7 +33,7 @@ files:
   docs:
     output: none
     includes:
-      - cudatoolkit
+      - cuda_version
       - docs
       - py_version
       - pytorch_cpu

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -8,7 +8,8 @@ files:
     includes:
       - checks
       - build
-      - cudatoolkit
+      - cuda
+      - cuda_version
       - py_version
       - run
       - test_python
@@ -17,11 +18,11 @@ files:
   test_cpp:
     output: none
     includes:
-      - cudatoolkit
+      - cuda_version
   test_python:
     output: none
     includes:
-      - cudatoolkit
+      - cuda_version
       - py_version
       - test_python
   checks:
@@ -40,7 +41,8 @@ files:
     output: none
     includes:
       - build
-      - cudatoolkit
+      - cuda
+      - cuda_version
       - py_version
       - run
       - pytorch_cpu
@@ -108,11 +110,34 @@ dependencies:
             packages:
               - nvcc_linux-aarch64=11.8
           - matrix:
+              cuda: "12.*"
+            packages:
+              - cuda-nvcc
+  cuda_version:
+    specific:
+      - output_types: conda
+        matrices:
+          - matrix:
+              cuda: "11.2"
+            packages:
+              - cuda-version=11.2
+          - matrix:
+              cuda: "11.4"
+            packages:
+              - cuda-version=11.4
+          - matrix:
+              cuda: "11.5"
+            packages:
+              - cuda-version=11.5
+          - matrix:
+              cuda: "11.8"
+            packages:
+              - cuda-version=11.8
+          - matrix:
               cuda: "12.0"
             packages:
               - cuda-version=12.0
-              - cuda-nvcc
-  cudatoolkit:
+  cuda:
     specific:
       - output_types: conda
         matrices:
@@ -137,9 +162,8 @@ dependencies:
               - cudatoolkit=11.8
               - cuda-nvtx=11.8
           - matrix:
-              cuda: "12.0"
+              cuda: "12.*"
             packages:
-              - cuda-version=12.0
               - cuda-cudart-dev
               - cuda-nvtx
   checks:


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/7.

Proposes splitting the `cuda-version` dependency in `dependencies.yaml` out to its own thing, separate from the bits of the CUDA Toolkit this project needs.

### Benefits of this change

* prevents accidental inclusion of multiple `cuda-version` version in environments
* reduces update effort (via enabling more use of globs like `"12.*"`)
* improves the chance that errors like "`conda` recipe is missing a dependency" are caught in CI

### Notes for Reviewers

This change was intended to just re-organize `dependencies.yaml`, but I do think the one additional change it introduces to `all_cuda-118_arch-x86_64.yaml` is a good one. I *think* requiring the `cuda-version` metapackage in all environments is useful to prevent against environment solves that result in runtime issues.

References:

* https://github.com/conda-forge/cuda-version-feedstock/blob/902045016fbc6e4dd1350a7390b0411f376d1a19/recipe/meta.yaml#L13-L18
* https://docs.conda.io/projects/conda-build/en/stable/resources/define-metadata.html#run-constrained