### PR TITLE
Revert "Exclude tests from builds (#127)"

### DIFF
--- a/python/pylibwholegraph/setup.py
+++ b/python/pylibwholegraph/setup.py
@@ -50,8 +50,7 @@ setup(
         include=[
             "pylibwholegraph",
             "pylibwholegraph.*",
-        ],
-        exclude=["*tests*"],
+        ]
     ),
     package_data={
         "pylibwholegraph": ["VERSION", "torch_cpp_ext/*.cpp",


### PR DESCRIPTION
This reverts commit 503cdcd1e6f38000967b60de59bd811c379c523c.

This change introduced [test errors](https://github.com/rapidsai/wholegraph/actions/runs/7827336502/job/21354958620), so reverting for `24.02` and will fix in `24.04` (in #128 most likely).