### PR TITLE
Forward-merge branch-24.02 to branch-24.04

### DIFF
--- a/python/pylibwholegraph/setup.py
+++ b/python/pylibwholegraph/setup.py
@@ -50,8 +50,7 @@ setup(
         include=[
             "pylibwholegraph",
             "pylibwholegraph.*",
-        ],
-        exclude=["*tests*"],
+        ]
     ),
     package_data={
         "pylibwholegraph": ["VERSION", "torch_cpp_ext/*.cpp",


### PR DESCRIPTION
Forward-merge triggered by push to `branch-24.02` that creates a PR to keep `branch-24.04` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.