### PR TITLE
Add support for Python 3.11, require NumPy 1.23+

### DIFF
--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -38,7 +38,7 @@ dependencies:
 - pytest
 - pytest-forked
 - pytest-xdist
-- python>=3.9,<3.11
+- python>=3.9,<3.12
 - pytorch-cuda=11.8
 - pytorch=2.0.0
 - recommonmark

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -30,7 +30,7 @@ dependencies:
 - nbsphinx
 - nccl
 - ninja
-- numpy>=1.17
+- numpy>=1.23
 - numpydoc
 - nvcc_linux-64=11.8
 - pre-commit

--- a/conda/environments/all_cuda-122_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-122_arch-x86_64.yaml
@@ -31,7 +31,7 @@ dependencies:
 - nbsphinx
 - nccl
 - ninja
-- numpy>=1.17
+- numpy>=1.23
 - numpydoc
 - pre-commit
 - pydata-sphinx-theme

--- a/conda/environments/all_cuda-122_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-122_arch-x86_64.yaml
@@ -38,7 +38,7 @@ dependencies:
 - pytest
 - pytest-forked
 - pytest-xdist
-- python>=3.9,<3.11
+- python>=3.9,<3.12
 - recommonmark
 - scikit-build
 - sphinx-copybutton

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -213,7 +213,7 @@ dependencies:
       - output_types: [conda, requirements]
         packages:
           - ninja
-          - numpy>=1.17
+          - numpy>=1.23
           - pytest
           - pytest-forked
           - pytest-xdist

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -188,8 +188,12 @@ dependencies:
             packages:
               - python=3.10
           - matrix:
+              py: "3.11"
             packages:
-              - python>=3.9,<3.11
+              - python=3.11
+          - matrix:
+            packages:
+              - python>=3.9,<3.12
   run:
     common:
       - output_types: [conda, requirements]

--- a/python/pylibwholegraph/pyproject.toml
+++ b/python/pylibwholegraph/pyproject.toml
@@ -41,7 +41,6 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.11",
 ]
 
 [tool.setuptools]

--- a/python/pylibwholegraph/pyproject.toml
+++ b/python/pylibwholegraph/pyproject.toml
@@ -41,6 +41,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.11",
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/3

This PR adds support for Python 3.11.

It also bumps uses of `NumPy` to `numpy>=1.23`, see https://github.com/rapidsai/build-planning/issues/3#issuecomment-1967952280.

## Notes for Reviewers

This is part of ongoing work to add Python 3.11 support across RAPIDS.

The Python 3.11 CI workflows introduced in https://github.com/rapidsai/shared-workflows/pull/176 are *optional*... they are not yet required to run successfully for PRs to be merged.

This PR can be merged once all jobs are running successfully (including the non-required jobs for Python 3.11). The CI logs should be verified that the jobs are building and testing with Python 3.11.

See https://github.com/rapidsai/shared-workflows/pull/176 for more details.
