### PR TITLE
Use default `rapids-cmake` CUDA_ARCHITECTURES

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -33,9 +33,6 @@ include(rapids-cuda)
 include(rapids-export)
 include(rapids-find)
 
-if (NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
-    set(CMAKE_CUDA_ARCHITECTURES 70-real 80-real 86)
-endif ()
 rapids_cuda_init_architectures(WHOLEGRAPH)
 
 project(WHOLEGRAPH VERSION ${WHOLEGRAPH_VERSION} LANGUAGES CXX CUDA)

--- a/python/pylibwholegraph/CMakeLists.txt
+++ b/python/pylibwholegraph/CMakeLists.txt
@@ -31,9 +31,6 @@ include(rapids-cmake)
 include(rapids-cuda)
 include(rapids-cpm)
 
-if (NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
-    set(CMAKE_CUDA_ARCHITECTURES 70-real 80-real 86)
-endif ()
 rapids_cuda_init_architectures(PYLIBWHOLEGRAPH)
 
 project(PYLIBWHOLEGRAPH VERSION ${WHOLEGRAPH_VERSION} LANGUAGES C CXX CUDA)


### PR DESCRIPTION
CMake [initializes `CMAKE_CUDA_ARCHITECTURES` from the `CUDAARCHS` environment variable](https://cmake.org/cmake/help/latest/variable/CMAKE_CUDA_ARCHITECTURES.html).

Defaulting `CMAKE_CUDA_ARCHITECTURES` to a fixed list of archs prevents CMake from initializing the value from the envvar.

This PR skips setting `CMAKE_CUDA_ARCHITECTURES`, and instead uses `rapids-cmake` default behavior of [initializing from the `CUDAARCHS` envvar](https://github.com/rapidsai/rapids-cmake/blob/branch-24.04/rapids-cmake/cuda/init_architectures.cmake#L73-L93) and falling back to the same default [archs list](https://github.com/rapidsai/rapids-cmake/blob/branch-24.04/rapids-cmake/cuda/set_architectures.cmake#L54) as is currently used in `build.sh`.