### PR TITLE
Update script input name

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,7 +34,7 @@ jobs:
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
       sha: ${{ inputs.sha }}
-      build_script: ci/build_cpp.sh
+      script: ci/build_cpp.sh
   python-build:
     needs: [cpp-build]
     secrets: inherit
@@ -44,7 +44,7 @@ jobs:
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
       sha: ${{ inputs.sha }}
-      build_script: ci/build_python.sh
+      script: ci/build_python.sh
   docs-build:
     if: github.ref_type == 'branch'
     needs: [python-build]


### PR DESCRIPTION
This PR updates the script inputs in the relevant workflows from `build_script` and `test_script` to `script`. 

Depends on https://github.com/rapidsai/shared-workflows/pull/191
