### PR TITLE
fix CI issue due to pytorch and mkl version conflict

### DIFF
--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -49,6 +49,7 @@ PACKAGES="pylibwholegraph"
 rapids-mamba-retry install \
   --channel "${CPP_CHANNEL}" \
   --channel "${PYTHON_CHANNEL}" \
+  'mkl<2024.1.0' \
   "${PACKAGES}"
 
 rapids-logger "Check GPU usage"


### PR DESCRIPTION
mkl2024.1.0 conflicts with pytorch, this PR constrains mkl<2024.1.0 in the test scripts where pytorch is required.