### PR TITLE
Migrate to `{{ stdlib("c") }}`

### DIFF
--- a/conda/recipes/libwholegraph/conda_build_config.yaml
+++ b/conda/recipes/libwholegraph/conda_build_config.yaml
@@ -25,5 +25,5 @@ gtest_version:
 gmock_version:
   - ">=1.13.0"
 
-sysroot_version:
+c_stdlib_version:
   - "2.17"

--- a/conda/recipes/libwholegraph/meta.yaml
+++ b/conda/recipes/libwholegraph/meta.yaml
@@ -49,7 +49,7 @@ requirements:
     - cuda-version ={{ cuda_version }}
     - cmake {{ cmake_version }}
     - ninja
-    - sysroot_{{ target_platform }} {{ sysroot_version }}
+    - {{ stdlib("c") }}
   host:
     {% if cuda_major == "11" %}
     - cudatoolkit

--- a/conda/recipes/pylibwholegraph/conda_build_config.yaml
+++ b/conda/recipes/pylibwholegraph/conda_build_config.yaml
@@ -16,5 +16,5 @@ cmake_version:
 scikit_build_core_version:
   - ">=0.7.0"
 
-sysroot_version:
+c_stdlib_version:
   - "2.17"

--- a/conda/recipes/pylibwholegraph/meta.yaml
+++ b/conda/recipes/pylibwholegraph/meta.yaml
@@ -54,7 +54,7 @@ requirements:
     - cmake {{ cmake_version }}
     - ninja
     - doxygen =1.8.20
-    - sysroot_{{ target_platform }} {{ sysroot_version }}
+    - {{ stdlib("c") }}
   host:
     - cuda-version ={{ cuda_version }}
     {% if cuda_major == "11" %}


### PR DESCRIPTION
The `sysroot*` syntax is getting phased out (conda-forge/conda-forge.github.io#2102).
The recommendation is to move to `{{ stdlib("c") }}`.
