### PR TITLE
a quick fix to wholememory tensor gather default data type

### DIFF
--- a/python/pylibwholegraph/pylibwholegraph/torch/tensor.py
+++ b/python/pylibwholegraph/pylibwholegraph/torch/tensor.py
@@ -67,7 +67,7 @@ class WholeMemoryTensor(object):
         embedding_count = indice.shape[0]
         current_cuda_device = "cuda:%d" % (torch.cuda.current_device(),)
         output_dtype = (
-            force_dtype if force_dtype is not None else self.embedding_tensor.dtype
+            force_dtype if force_dtype is not None else self.dtype
         )
         output_tensor = torch.empty(
             [embedding_count, embedding_dim],


### PR DESCRIPTION
A quick fixes to this issue (https://github.com/rapidsai/wholegraph/issues/168). Set correct default wholememory tensor gather results data type.