### PR TITLE
Mnnvl with split comm

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -195,6 +195,7 @@ PUBLIC
     CUDA::cuda_driver
     CUDA::cudart${_ctk_static_suffix}
     raft::raft
+    nvidia-ml
 PRIVATE
     NCCL::NCCL
 )

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -195,10 +195,14 @@ PUBLIC
     CUDA::cuda_driver
     CUDA::cudart${_ctk_static_suffix}
     raft::raft
-    nvidia-ml
 PRIVATE
     NCCL::NCCL
 )
+
+if (CUDAToolkit_VERSION VERSION_GREATER "12.3")
+    # Link the NVML library if CUDA version is greater than 12.3
+    target_link_libraries(wholegraph PRIVATE CUDA::nvml)
+endif()
 
 if(BUILD_WITH_NVSHMEM)
 

--- a/cpp/include/wholememory/wholememory.h
+++ b/cpp/include/wholememory/wholememory.h
@@ -40,6 +40,7 @@ enum wholememory_error_code_t {
   WHOLEMEMORY_INVALID_VALUE,       /*!< input value is invalid */
   WHOLEMEMORY_OUT_OF_MEMORY,       /*!< out of memory */
   WHOLEMEMORY_NOT_SUPPORTED,       /*!< not supported */
+  WHOLEMEMORY_SYSTEM_ERROR,        /*!< system error>*/
 };
 
 #define WHOLEMEMORY_RETURN_ON_FAIL(X)                                                 \
@@ -111,6 +112,15 @@ wholememory_error_code_t wholememory_finalize();
  * An Opaque handle to communicator
  */
 typedef struct wholememory_comm_* wholememory_comm_t;
+
+struct clique_info_t {
+  int is_in_clique;  // is_in_clique >0 means the gpu belongs to  a mnnvl domain
+  int clique_first_rank;
+  int clique_rank;      // the rank of gpu in a mnnvl domain
+  int clique_rank_num;  // the num of gpu in the mnnvl domain
+  int clique_id;        // the id of clique
+  int clique_num;       // the num of clique in the comm domain.
+};
 
 #define WHOLEMEMORY_UNIQUE_ID_BYTES (128)
 /**
@@ -195,6 +205,9 @@ wholememory_error_code_t wholememory_communicator_get_rank(int* rank, wholememor
  * @return : wholememory_error_code_t
  */
 wholememory_error_code_t wholememory_communicator_get_size(int* size, wholememory_comm_t comm);
+
+wholememory_error_code_t wholememory_communicator_get_clique_info(clique_info_t* clique_info,
+                                                                  wholememory_comm_t comm);
 
 bool wholememory_communicator_is_bind_to_nvshmem(wholememory_comm_t comm);
 
@@ -412,6 +425,7 @@ wholememory_error_code_t wholememory_store_to_file(wholememory_handle_t wholemem
  */
 bool wholememory_is_intranode_communicator(wholememory_comm_t comm);
 
+bool wholememory_is_intra_mnnvl_communicator(wholememory_comm_t comm);
 bool wholememory_is_build_with_nvshmem();
 #ifdef WITH_NVSHMEM_SUPPORT
 wholememory_error_code_t wholememory_get_nvshmem_reference(

--- a/cpp/include/wholememory/wholememory.h
+++ b/cpp/include/wholememory/wholememory.h
@@ -90,6 +90,7 @@ enum LogLevel {
   LEVEL_TRACE      /*!< Trace */
 };
 
+#define WHOLEMEMORY_SPILT_NO_COLOR -1
 /**
  * Initialize WholeMemory library
  * @param flags : reserved should be 0
@@ -142,6 +143,24 @@ wholememory_error_code_t wholememory_create_communicator(wholememory_comm_t* com
                                                          int rank,
                                                          int size);
 
+/**
+ * Split WholeMemory Communicator
+ * @param new_comm: returned the splited wholeMemory Communicator
+ * @param comm: WholeMemory Communicator to split
+ * @param color: color value to split communicator,Ranks which pass the same color value will be
+ * part of the same group; color must be a non-negative value. If it is passed as
+ * WHOLEMEMORY_SPLIT_NOCOLOR, it means that the rank will not be part of any group, therefore
+ * returning NULL as newcomm.
+ * @param key: key value to split communicator,the value of key will determine the
+ * rank order, and the smaller key means the smaller rank in new communicator. If keys are equal
+ * between ranks, then the rank in the original communicator will be used to order ranks.
+ * @return : wholememory_error_code_t
+
+*/
+wholememory_error_code_t wholememory_split_communicator(wholememory_comm_t* new_comm,
+                                                        wholememory_comm_t comm,
+                                                        int color,
+                                                        int key);
 /**
  * Destroy WholeMemory Communicator
  * @param comm : WholeMemory Communicator to destroy

--- a/cpp/src/wholememory/communicator.hpp
+++ b/cpp/src/wholememory/communicator.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -266,6 +266,11 @@ wholememory_error_code_t create_communicator(wholememory_comm_t* comm,
                                              wholememory_unique_id_t unique_id,
                                              int rank,
                                              int size) noexcept;
+
+wholememory_error_code_t split_communicator(wholememory_comm_t* new_comm,
+                                            wholememory_comm_t parent_comm,
+                                            int color,
+                                            int key) noexcept;
 
 wholememory_error_code_t destroy_communicator_locked(wholememory_comm_t comm) noexcept;
 

--- a/cpp/src/wholememory/communicator.hpp
+++ b/cpp/src/wholememory/communicator.hpp
@@ -192,6 +192,7 @@ struct wholememory_comm_ {
 
   bool is_intranode() const;
 
+  bool is_intra_mnnvl() const;
   bool support_type_location(wholememory_memory_type_t memory_type,
                              wholememory_memory_location_t memory_location) const;
 
@@ -212,10 +213,13 @@ struct wholememory_comm_ {
   int intra_node_rank_num       = 0;
   int intra_node_first_rank_pid = -1;
 
+  clique_info_t clique_info;
+
   int comm_id = -1;
 
   int dev_id            = -1;
   int local_gpu_ids[16] = {0};
+  bool support_mnnvl    = false;
 
   size_t alloc_granularity = 2 * 1024 * 1024UL;
 
@@ -287,9 +291,14 @@ wholememory_error_code_t communicator_get_rank(int* rank, wholememory_comm_t com
 
 wholememory_error_code_t communicator_get_size(int* size, wholememory_comm_t comm) noexcept;
 
+wholememory_error_code_t communicator_get_clique_info(clique_info_t* clique_info,
+                                                      wholememory_comm_t comm) noexcept;
+
 void communicator_barrier(wholememory_comm_t comm);
 
 bool is_intranode_communicator(wholememory_comm_t comm) noexcept;
+
+bool is_intra_mnnvl_communicator(wholememory_comm_t comm) noexcept;
 
 std::string get_temporary_directory_path(wholememory_comm_t comm);
 

--- a/cpp/src/wholememory/memory_handle.cpp
+++ b/cpp/src/wholememory/memory_handle.cpp
@@ -1318,7 +1318,7 @@ class continuous_mnnvl_wholememory_impl : public continuous_device_wholememory_i
   void check_valid()
   {
     if (location_ == WHOLEMEMORY_ML_HOST) { WHOLEMEMORY_CHECK_NOTHROW(SupportEGM()); }
-    WHOLEMEMORY_CHECK_NOTHROW(SupportMNNVL());
+    WHOLEMEMORY_CHECK_NOTHROW(comm_->is_intra_mnnvl());
   }
   void create_memory() override
   {

--- a/cpp/src/wholememory/nccl_comms.cpp
+++ b/cpp/src/wholememory/nccl_comms.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -513,5 +513,7 @@ void nccl_comms::device_multicast_sendrecv(const void* sendbuf,
 void nccl_comms::group_start() const { RAFT_NCCL_TRY(ncclGroupStart()); }
 
 void nccl_comms::group_end() const { RAFT_NCCL_TRY(ncclGroupEnd()); }
+
+ncclComm_t nccl_comms::raw_nccl_comm() const { return nccl_comm_; }
 
 }  // namespace wholememory

--- a/cpp/src/wholememory/nccl_comms.hpp
+++ b/cpp/src/wholememory/nccl_comms.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -197,6 +197,7 @@ class nccl_comms {
   void group_start() const;
 
   void group_end() const;
+  ncclComm_t raw_nccl_comm() const;
 
  private:
   ncclComm_t nccl_comm_;

--- a/cpp/src/wholememory/system_info.cpp
+++ b/cpp/src/wholememory/system_info.cpp
@@ -133,18 +133,18 @@ wholememory_error_code_t NvmlEnsureInitialized()
   return initResult;
 }
 
-wholememory_error_code_t GetGpuFabricInfoV(int dev, nvmlGpuFabricInfoV_t* gpuFabricInfo)
+wholememory_error_code_t GetGpuFabricInfo(int dev, nvmlGpuFabricInfo_t* gpuFabricInfo)
 {
   WHOLEMEMORY_CHECK_NOTHROW(NvmlEnsureInitialized() == WHOLEMEMORY_SUCCESS);
   std::lock_guard<std::mutex> locked(lock);
-  gpuFabricInfo->version = nvmlGpuFabricInfo_v2;
+  // gpuFabricInfo->version = nvmlGpuFabricInfo_v2;
   nvmlDevice_t nvml_device;
   nvmlReturn_t ret = nvmlDeviceGetHandleByIndex(dev, &nvml_device);
   WHOLEMEMORY_EXPECTS_NOTHROW(
     ret == NVML_SUCCESS, "nvmlDeviceGetHandleByIndex error:%s", nvmlErrorString(ret));
-  ret = nvmlDeviceGetGpuFabricInfoV(nvml_device, gpuFabricInfo);
+  ret = nvmlDeviceGetGpuFabricInfo(nvml_device, gpuFabricInfo);
   WHOLEMEMORY_EXPECTS_NOTHROW(
-    ret == NVML_SUCCESS, "nvmlDeviceGetGpuFabricInfoV error:%s", nvmlErrorString(ret));
+    ret == NVML_SUCCESS, "nvmlDeviceGetGpuFabricInfo error:%s", nvmlErrorString(ret));
 
   return WHOLEMEMORY_SUCCESS;
 }

--- a/cpp/src/wholememory/system_info.cpp
+++ b/cpp/src/wholememory/system_info.cpp
@@ -20,9 +20,10 @@
 #include "cuda_macros.hpp"
 
 #include "logger.hpp"
-#include "nvml.h"
 #include "system_info.hpp"
 #include "wholememory/wholememory.h"
+#if CUDA_VERSION >= 12030
+#include <nvml.h>
 
 namespace {
 
@@ -31,6 +32,8 @@ bool nvmlInitialized                = false;
 thread_local bool threadInitialized = false;
 wholememory_error_code_t initResult;
 };  // namespace
+
+#endif
 bool DevAttrPagebleMemoryAccess()
 {
   int current_dev_id = -1;
@@ -107,6 +110,7 @@ bool SupportEGM()
 }
 
 // bool SupportMNNVLForEGM() { return SupportMNNVL() && SupportEGM(); }
+#if CUDA_VERSION >= 12030
 
 namespace wholememory {
 
@@ -150,3 +154,4 @@ wholememory_error_code_t GetGpuFabricInfo(int dev, nvmlGpuFabricInfo_t* gpuFabri
 }
 
 };  // namespace wholememory
+#endif

--- a/cpp/src/wholememory/system_info.hpp
+++ b/cpp/src/wholememory/system_info.hpp
@@ -33,5 +33,5 @@ bool SupportEGM();
 
 // bool SupportMNNVLForEGM();
 namespace wholememory {
-wholememory_error_code_t GetGpuFabricInfoV(int dev, nvmlGpuFabricInfoV_t* gpuFabricInfo);
+wholememory_error_code_t GetGpuFabricInfo(int dev, nvmlGpuFabricInfo_t* gpuFabricInfo);
 }

--- a/cpp/src/wholememory/system_info.hpp
+++ b/cpp/src/wholememory/system_info.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
  */
 #pragma once
 
+#include "nvml.h"
+#include "wholememory/wholememory.h"
 bool DevAttrPagebleMemoryAccess();
 
 bool DeviceCanAccessPeer(int peer_device);
@@ -29,4 +31,7 @@ bool SupportMNNVL();
 
 bool SupportEGM();
 
-bool SupportMNNVLForEGM();
+// bool SupportMNNVLForEGM();
+namespace wholememory {
+wholememory_error_code_t GetGpuFabricInfoV(int dev, nvmlGpuFabricInfoV_t* gpuFabricInfo);
+}

--- a/cpp/src/wholememory/system_info.hpp
+++ b/cpp/src/wholememory/system_info.hpp
@@ -15,8 +15,11 @@
  */
 #pragma once
 
-#include "nvml.h"
 #include "wholememory/wholememory.h"
+
+#if CUDA_VERSION >= 12030
+#include <nvml.h>
+#endif
 bool DevAttrPagebleMemoryAccess();
 
 bool DeviceCanAccessPeer(int peer_device);
@@ -32,6 +35,9 @@ bool SupportMNNVL();
 bool SupportEGM();
 
 // bool SupportMNNVLForEGM();
+#if CUDA_VERSION >= 12030
 namespace wholememory {
 wholememory_error_code_t GetGpuFabricInfo(int dev, nvmlGpuFabricInfo_t* gpuFabricInfo);
 }
+
+#endif

--- a/cpp/src/wholememory/wholememory.cpp
+++ b/cpp/src/wholememory/wholememory.cpp
@@ -274,6 +274,17 @@ bool wholememory_is_intranode_communicator(wholememory_comm_t comm)
   return wholememory::is_intranode_communicator(comm);
 }
 
+bool wholememory_is_intra_mnnvl_communicator(wholememory_comm_t comm)
+{
+  return wholememory::is_intra_mnnvl_communicator(comm);
+}
+
+wholememory_error_code_t wholememory_communicator_get_clique_info(clique_info_t* clique_info,
+                                                                  wholememory_comm_t comm)
+{
+  return wholememory::communicator_get_clique_info(clique_info, comm);
+}
+
 bool wholememory_is_build_with_nvshmem()
 {
 #ifdef WITH_NVSHMEM_SUPPORT

--- a/cpp/src/wholememory/wholememory.cpp
+++ b/cpp/src/wholememory/wholememory.cpp
@@ -45,6 +45,14 @@ wholememory_error_code_t wholememory_create_communicator(wholememory_comm_t* com
   return wholememory::create_communicator(comm, unique_id, rank, size);
 }
 
+wholememory_error_code_t wholememory_split_communicator(wholememory_comm_t* new_comm,
+                                                        wholememory_comm_t comm,
+                                                        int color,
+                                                        int key)
+{
+  return wholememory::split_communicator(new_comm, comm, color, key);
+}
+
 wholememory_error_code_t wholememory_destroy_communicator(wholememory_comm_t comm)
 {
   return wholememory::destroy_communicator(comm);

--- a/python/pylibwholegraph/pylibwholegraph/binding/wholememory_binding.pyx
+++ b/python/pylibwholegraph/pylibwholegraph/binding/wholememory_binding.pyx
@@ -186,6 +186,11 @@ cdef extern from "wholememory/wholememory.h":
                                                                             wholememory_comm_t comm)
     cdef bool wholememory_is_intranode_communicator(wholememory_comm_t comm)
 
+    cdef wholememory_error_code_t wholememory_split_communicator(wholememory_comm_t* new_comm,
+                                                        wholememory_comm_t comm,
+                                                        int color,
+                                                        int key)
+
 cpdef enum WholeMemoryErrorCode:
     Success = WHOLEMEMORY_SUCCESS
     UnknowError = WHOLEMEMORY_UNKNOW_ERROR
@@ -1624,6 +1629,10 @@ def create_communicator(PyWholeMemoryUniqueID py_uid, int world_rank, int world_
 def destroy_communicator(PyWholeMemoryComm py_comm):
     check_wholememory_error_code(wholememory_destroy_communicator(py_comm.comm_id))
 
+def split_communicator(PyWholeMemoryComm comm,int color,int key):
+    py_comm = PyWholeMemoryComm()
+    check_wholememory_error_code(wholememory_split_communicator(&py_comm.comm_id,comm.comm_id,color,key))
+    return py_comm
 
 def communicator_set_distributed_backend(PyWholeMemoryComm py_comm,WholeMemoryDistributedBackend distributed_backend):
     check_wholememory_error_code(wholememory_communicator_set_distributed_backend(py_comm.comm_id,int(distributed_backend)))

--- a/python/pylibwholegraph/pylibwholegraph/binding/wholememory_binding.pyx
+++ b/python/pylibwholegraph/pylibwholegraph/binding/wholememory_binding.pyx
@@ -198,17 +198,6 @@ cdef extern from "wholememory/wholememory.h":
 
     cdef wholememory_error_code_t wholememory_communicator_get_clique_info(clique_info_t* clique_info, wholememory_comm_t comm)
 
-    # struct clique_info_t {
-#   int is_in_clique;  // is_in_clique >0 means the gpu belongs to  a mnnvl domain
-#   int clique_first_rank;
-#   int clique_rank;      // the rank of gpu in a mnnvl domain
-#   int clique_rank_num;  // the num of gpu in the mnnvl domain
-#   int clique_id;        // the id of clique
-#   int clique_num;       // the num of clique in the comm domain.
-# };
-# 返回一个tuple
-
-
 
     cdef wholememory_error_code_t wholememory_split_communicator(wholememory_comm_t* new_comm,
                                                         wholememory_comm_t comm,

--- a/python/pylibwholegraph/pylibwholegraph/torch/__init__.py
+++ b/python/pylibwholegraph/pylibwholegraph/torch/__init__.py
@@ -21,6 +21,7 @@ from .comm import (
     get_local_node_communicator,
     get_local_device_communicator,
     split_communicator,
+    get_local_mnnvl_communicator,
 )
 
 from .embedding import (

--- a/python/pylibwholegraph/pylibwholegraph/torch/__init__.py
+++ b/python/pylibwholegraph/pylibwholegraph/torch/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2023, NVIDIA CORPORATION.
+# Copyright (c) 2019-2024, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -20,6 +20,7 @@ from .comm import (
     get_global_communicator,
     get_local_node_communicator,
     get_local_device_communicator,
+    split_communicator,
 )
 
 from .embedding import (

--- a/python/pylibwholegraph/pylibwholegraph/torch/comm.py
+++ b/python/pylibwholegraph/pylibwholegraph/torch/comm.py
@@ -25,6 +25,7 @@ from .utils import (
 global_communicators = {}
 local_node_communicator = None
 local_device_communicator = None
+local_mnnvl_communicator = None
 
 all_comm_world_rank = 0
 all_comm_world_size = 1
@@ -34,10 +35,11 @@ all_comm_local_size = 1
 
 def reset_communicators():
     global all_comm_world_rank, all_comm_world_size, all_comm_local_rank, all_comm_local_size
-    global global_communicators, local_node_communicator, local_device_communicator
+    global global_communicators, local_node_communicator, local_device_communicator, local_mnnvl_communicator
     global_communicators = {}
     local_node_communicator = None
     local_device_communicator = None
+    local_mnnvl_communicator = None
 
     all_comm_world_rank = 0
     all_comm_world_size = 1
@@ -81,6 +83,18 @@ class WholeMemoryCommunicator(object):
     def get_size(self):
         """Get world size of this communicator"""
         return self.wmb_comm.get_size()
+
+    def get_clique_info(self):
+        """Get info of clique where current process is located, a clique is made up of GPUs in same mnnvl domain.
+        return:
+        is_in_clique: is_in_clique >0 means the gpu belongs to  a mnnvl domain
+        clique_first_rank; // the rank in the comm of first gpu in the clique ,
+        clique_rank;      // the rank of gpu in a mnnvl domain
+        clique_rank_num;  // the num of gpu in the mnnvl domain
+        clique_id;        // the id of clique
+        clique_num;       // the num of clique in the comm domain.
+        """
+        return self.wmb_comm.get_clique_info()
 
     def barrier(self):
         """
@@ -185,7 +199,7 @@ def get_global_communicator(distributed_backend="nccl"):
     Get the global communicator of this job
     :return: WholeMemoryCommunicator that has all GPUs in it.
     """
-    global global_communicators, local_node_communicator, local_device_communicator
+    global global_communicators, local_node_communicator, local_device_communicator, local_mnnvl_communicator
     global all_comm_local_size, all_comm_world_size
     if distributed_backend not in global_communicators:
         global_communicator = create_group_communicator()
@@ -209,7 +223,7 @@ def get_local_node_communicator():
     Get the local node communicator of this job
     :return: WholeMemoryCommunicator that has GPUs in the same node.
     """
-    global global_communicators, local_node_communicator, local_device_communicator
+    global global_communicators, local_node_communicator, local_device_communicator, local_mnnvl_communicator
     global all_comm_local_size, all_comm_world_size
     if local_node_communicator is None:
         local_node_communicator = create_group_communicator(all_comm_local_size)
@@ -227,7 +241,7 @@ def get_local_device_communicator():
     Get the local device communicator of this job
     :return: WholeMemoryCommunicator that has only the GPU belonging to current process.
     """
-    global global_communicators, local_node_communicator, local_device_communicator
+    global global_communicators, local_node_communicator, local_device_communicator, local_mnnvl_communicator
     global all_comm_local_size, all_comm_world_size
     if local_device_communicator is None:
         local_device_communicator = create_group_communicator(1)
@@ -238,6 +252,47 @@ def get_local_device_communicator():
             assert "nccl" not in global_communicators
             global_communicators["nccl"] = local_device_communicator
     return local_device_communicator
+
+
+def get_local_mnnvl_communicator():
+    """ """
+    global global_communicators, local_node_communicator, local_device_communicator, local_mnnvl_communicator
+    global all_comm_local_size, all_comm_world_size
+
+    if local_mnnvl_communicator is None:
+        g_communicator = get_global_communicator()
+        (
+            is_in_clique,
+            clique_first_rank,
+            clique_rank,
+            clique_rank_num,
+            clique_id,
+            clique_num,
+        ) = g_communicator.get_clique_info()
+        if not is_in_clique:
+            raise RuntimeError(
+                "the gpu does not belong to any mnnvl domain,can not create local_mnnvl_communicator"
+            )
+        wm_uid = wmb.PyWholeMemoryUniqueID()
+
+        if clique_first_rank == g_communicator.get_rank():
+            tmp_wm_uid = wmb.create_unique_id()
+        else:
+            tmp_wm_uid = wmb.PyWholeMemoryUniqueID()
+        uid_th = torch.utils.dlpack.from_dlpack(tmp_wm_uid.__dlpack__())
+        uid_th_cuda = uid_th.cuda()
+        uid_th_cuda_tensor_list = [
+            torch.zeros_like(uid_th_cuda)
+        ] * g_communicator.get_size()
+
+        dist.all_gather(uid_th_cuda_tensor_list, uid_th_cuda)
+        uid_th_cuda_root = uid_th_cuda_tensor_list[clique_first_rank]
+        wm_uid_th = torch.utils.dlpack.from_dlpack(wm_uid.__dlpack__())
+        wm_uid_th.copy_(uid_th_cuda_root.cpu())
+        wm_mnnvl_comm = wmb.create_communicator(wm_uid, clique_rank, clique_rank_num)
+        local_mnnvl_communicator = WholeMemoryCommunicator(wm_mnnvl_comm)
+
+    return local_mnnvl_communicator
 
 
 def comm_set_distributed_backend(

--- a/python/pylibwholegraph/pylibwholegraph/torch/comm.py
+++ b/python/pylibwholegraph/pylibwholegraph/torch/comm.py
@@ -282,8 +282,8 @@ def get_local_mnnvl_communicator():
         uid_th = torch.utils.dlpack.from_dlpack(tmp_wm_uid.__dlpack__())
         uid_th_cuda = uid_th.cuda()
         uid_th_cuda_tensor_list = [
-            torch.zeros_like(uid_th_cuda)
-        ] * g_communicator.get_size()
+            torch.zeros_like(uid_th_cuda) for _ in range(dist.get_world_size())
+        ]
 
         dist.all_gather(uid_th_cuda_tensor_list, uid_th_cuda)
         uid_th_cuda_root = uid_th_cuda_tensor_list[clique_first_rank]


### PR DESCRIPTION
support split comm and get_local_mnnvl_comm

split_comm
```

def split_communicator(comm: WholeMemoryCommunicator, color: int, key: int = 0):
    """Split Communicator.
    Creates a set of new communicators from an existing one. Ranks which pass the same color value will be part of the
    same group; color must be a non-negative value.
    The value of key will determine the rank order, and the smaller key means the smaller rank in new communicator.
    If keys are equal between ranks, then the rank in the original communicator will be used to order ranks.
    """
```