### PR TITLE
decouple embedding creation from optimizer

### DIFF
--- a/cpp/include/wholememory/embedding.h
+++ b/cpp/include/wholememory/embedding.h
@@ -128,7 +128,6 @@ wholememory_error_code_t wholememory_destroy_embedding_cache_policy(
  * @param comm : WholeMemory Communicator
  * @param memory_type : Memory Type of the underlying WholeMemory
  * @param memory_location : Memory Location of the underlying WholeMemory
- * @param optimizer : Optimizer to use for training, if don't train embedding, use nullptr
  * @param cache_policy : Cache policy for this embedding, if don't use cache, use nullptr
  * @param user_defined_sms : User-defined sms number for raw embedding gather/scatter
  * @param round_robin_size : continuous embedding size in each rank under round-robin shard mode
@@ -140,7 +139,6 @@ wholememory_error_code_t wholememory_create_embedding(
   wholememory_comm_t comm,
   wholememory_memory_type_t memory_type,
   wholememory_memory_location_t memory_location,
-  wholememory_embedding_optimizer_t optimizer,
   wholememory_embedding_cache_policy_t cache_policy,
   int user_defined_sms = -1,
   int round_robin_size = 0);
@@ -160,6 +158,15 @@ wholememory_error_code_t wholememory_destroy_embedding(
  */
 wholememory_tensor_t wholememory_embedding_get_embedding_tensor(
   wholememory_embedding_t wholememory_embedding);
+
+/**
+ * Set Optimizer for WholeMemory Embedding
+ * @param wholememory_embedding : WholeMemory Embedding
+ * @param optimizer : Optimizer to be set
+ * @return : wholememory_error_code_t
+ */
+wholememory_error_code_t wholememory_embedding_set_optimizer(
+  wholememory_embedding_t wholememory_embedding, wholememory_embedding_optimizer_t optimizer);
 
 /**
  * Gather from WholeMemory Embedding

--- a/cpp/src/wholememory/embedding.hpp
+++ b/cpp/src/wholememory/embedding.hpp
@@ -45,8 +45,7 @@ class embedding_base : public wholememory_embedding_ {
                                     wholememory_comm_t comm,
                                     wholememory_memory_type_t memory_type,
                                     wholememory_memory_location_t memory_location,
-                                    wholememory_embedding_cache_policy_t policy,
-                                    wholememory_embedding_optimizer_t opt) noexcept;
+                                    wholememory_embedding_cache_policy_t policy) noexcept;
   void deallocate() noexcept;
   virtual wholememory_error_code_t gather(wholememory_tensor_t indices,
                                           wholememory_tensor_t output,
@@ -60,6 +59,8 @@ class embedding_base : public wholememory_embedding_ {
                                                  float lr,
                                                  wholememory_env_func_t* p_env_fns,
                                                  cudaStream_t stream);
+
+  wholememory_error_code_t set_optimizer(wholememory_embedding_optimizer_t opt);
 
   [[nodiscard]] const char* const* get_optimizer_state_names() const noexcept
   {
@@ -104,6 +105,7 @@ class embedding_base : public wholememory_embedding_ {
 
   int gather_sms_;
   int round_robin_size_;
+  wholememory_dtype_t embedding_dtype_                             = WHOLEMEMORY_DT_UNKNOWN;
   wholememory_comm_t raw_embedding_comm_                           = nullptr;
   wholememory::embedding_cache_base* cache_ptr_                    = nullptr;
   wholememory::embedding_optimizer_impl_base* optimizer_impl_base_ = nullptr;

--- a/cpp/tests/wholememory_ops/wholememory_embedding_gradient_apply_tests.cu
+++ b/cpp/tests/wholememory_ops/wholememory_embedding_gradient_apply_tests.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -592,10 +592,9 @@ TEST_P(WholeMemoryEmbeddingBackwardParameterTests, EmbeddingGatherGradientApplyT
                                              wm_comm,
                                              params.memory_type,
                                              params.memory_location,
-                                             optimizer,
                                              cache_policy),
                 WHOLEMEMORY_SUCCESS);
-
+      EXPECT_EQ(wholememory_embedding_set_optimizer(wm_embedding, optimizer), WHOLEMEMORY_SUCCESS);
       wholememory_tensor_t embedding_tensor =
         wholememory_embedding_get_embedding_tensor(wm_embedding);
       wholememory_tensor_t local_embed_tensor;

--- a/cpp/tests/wholememory_ops/wholememory_embedding_tests.cu
+++ b/cpp/tests/wholememory_ops/wholememory_embedding_tests.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -244,7 +244,6 @@ TEST_P(WholeMemoryEmbeddingParameterTests, EmbeddingGatherTest)
                                            wm_comm,
                                            params.memory_type,
                                            params.memory_location,
-                                           nullptr,
                                            cache_policy),
               WHOLEMEMORY_SUCCESS);
 

--- a/python/pylibwholegraph/pylibwholegraph/binding/wholememory_binding.pyx
+++ b/python/pylibwholegraph/pylibwholegraph/binding/wholememory_binding.pyx
@@ -624,13 +624,16 @@ cdef extern from "wholememory/embedding.h":
             wholememory_comm_t comm,
             wholememory_memory_type_t memory_type,
             wholememory_memory_location_t memory_location,
-            wholememory_embedding_optimizer_t optimizer,
             wholememory_embedding_cache_policy_t cache_policy,
             int user_defined_sms,
             int round_robin_size)
 
     cdef wholememory_error_code_t wholememory_destroy_embedding(
             wholememory_embedding_t wholememory_embedding)
+
+    cdef wholememory_error_code_t wholememory_embedding_set_optimizer(
+            wholememory_embedding_t  wholememory_embedding,
+            wholememory_embedding_optimizer_t optimizer);
 
     cdef wholememory_error_code_t wholememory_embedding_gather(wholememory_embedding_t wholememory_embedding,
                                                                wholememory_tensor_t indices,
@@ -700,6 +703,10 @@ cdef class WholeMemoryOptimizer:
             key_bytes = param_key.encode('utf-8')
             check_wholememory_error_code(
                 wholememory_optimizer_set_parameter(self.wm_optimizer, key_bytes, &param_value))
+
+    def add_embedding(self,
+                    PyWholeMemoryEmbedding embedding):
+        wholememory_embedding_set_optimizer(embedding.wm_embedding, self.wm_optimizer)
 
     def destroy_optimizer(self):
         if self.wm_optimizer == NULL:
@@ -789,7 +796,6 @@ cdef class PyWholeMemoryEmbedding:
                          PyWholeMemoryComm comm,
                          WholeMemoryMemoryType memory_type,
                          WholeMemoryMemoryLocation memory_location,
-                         WholeMemoryOptimizer optimizer,
                          WholeMemoryCachePolicy cache_policy,
                          int user_defined_sms,
                          int round_robin_size):
@@ -800,7 +806,6 @@ cdef class PyWholeMemoryEmbedding:
                                                                   comm.comm_id,
                                                                   self.memory_type,
                                                                   self.memory_location,
-                                                                  optimizer.wm_optimizer,
                                                                   cache_policy.cache_policy,
                                                                   user_defined_sms,
                                                                   round_robin_size))
@@ -847,7 +852,6 @@ def create_embedding(PyWholeMemoryTensorDescription tensor_desc,
                      PyWholeMemoryComm comm,
                      WholeMemoryMemoryType memory_type,
                      WholeMemoryMemoryLocation memory_location,
-                     WholeMemoryOptimizer optimizer,
                      WholeMemoryCachePolicy cache_policy,
                      int user_defined_sms,
                      int round_robin_size):
@@ -856,7 +860,6 @@ def create_embedding(PyWholeMemoryTensorDescription tensor_desc,
                                   comm,
                                   memory_type,
                                   memory_location,
-                                  optimizer,
                                   cache_policy,
                                   user_defined_sms,
                                   round_robin_size)

--- a/python/pylibwholegraph/pylibwholegraph/torch/embedding.py
+++ b/python/pylibwholegraph/pylibwholegraph/torch/embedding.py
@@ -45,10 +45,16 @@ class WholeMemoryOptimizer(object):
 
     def add_embedding(self, wm_embedding):
         """Add WholeMemory Embedding to this optimizer
-        NOTE: you don't need to call this method, it is automatic called when WholeMemory Embedding is created.
+        NOTE: you don't need to call this method, it is automatic called when WholeMemory Optimizer is created.
         :param wm_embedding: WholeMemory Embedding that use this optimizer
         :return: None
         """
+        assert isinstance(wm_embedding, WholeMemoryEmbedding)
+        if wm_embedding.wmb_optimizer is not None:
+            raise ValueError("optimizer can only be set once.")
+        wm_embedding.wmb_optimizer = self.wmb_opt
+        wm_embedding.dummy_input.requires_grad_(True)
+        self.wmb_opt.add_embedding(wm_embedding.wmb_embedding)
         self.embeddings.append(wm_embedding)
 
     def step(self, lr: float):
@@ -59,30 +65,6 @@ class WholeMemoryOptimizer(object):
             if wm_embedding.need_apply:
                 wm_embedding.apply_gradients(lr)
         self.global_comm.barrier()
-
-
-def create_wholememory_optimizer(optimizer_type: str, param_dict: dict):
-    """
-    Create WholeMemoryOptimizer.
-    :param optimizer_type: Type of the Optimizer
-    :param param_dict: parameters of the optimizer
-    :return: WholeMemoryOptimizer
-    """
-    wm_optimizer = WholeMemoryOptimizer(get_global_communicator())
-    wm_optimizer.wmb_opt.create_optimizer(
-        str_to_wmb_wholememory_optimizer_type(optimizer_type), param_dict
-    )
-    return wm_optimizer
-
-
-def destroy_wholememory_optimizer(optimizer: WholeMemoryOptimizer):
-    """
-    Destroy WholeMemoryOptimizer
-    :param optimizer: WholeMemoryOptimizer to destroy
-    :return: None
-    """
-    optimizer.wmb_opt.destroy_optimizer()
-    optimizer.wmb_opt = None
 
 
 class WholeMemoryCachePolicy(object):
@@ -261,7 +243,6 @@ class WholeMemoryEmbedding(object):
     def __init__(
         self,
         wmb_embedding: wmb.PyWholeMemoryEmbedding,
-        wmb_optimizer: Union[WholeMemoryOptimizer, None],
         wmb_cache_policy: Union[WholeMemoryCachePolicy, None],
     ):
         super().__init__()
@@ -269,16 +250,15 @@ class WholeMemoryEmbedding(object):
         self.embedding_tensor = None
         self.optimizer_states = None
 
-        self.wmb_optimizer = wmb_optimizer
         self.wmb_cache_policy = wmb_cache_policy
 
         self.adjust_cache = True if self.wmb_cache_policy is not None else False
 
-        dummy_input_need_grad = True if self.wmb_optimizer is not None else False
-        self.dummy_input = torch.nn.Parameter(
-            torch.zeros(1), requires_grad=dummy_input_need_grad
-        )
+        self.wmb_optimizer = None
 
+        self.dummy_input = torch.nn.Parameter(
+            torch.zeros(1), requires_grad=False
+        )
         self.need_apply = False
         self.sparse_indices = []
         self.sparse_grads = []
@@ -403,7 +383,6 @@ def create_embedding(
     dtype: torch.dtype,
     sizes: List[int],
     *,
-    optimizer: Union[WholeMemoryOptimizer, None] = None,
     cache_policy: Union[WholeMemoryCachePolicy, None] = None,
     random_init: bool = False,
     gather_sms: int = -1,
@@ -416,16 +395,11 @@ def create_embedding(
     :param memory_location: WholeMemory location, should be cpu or cuda
     :param dtype: data type
     :param sizes: size of the embedding, must be 2D
-    :param optimizer: optimizer
     :param cache_policy: cache policy
     :param gather_sms: the number of SMs used in gather process
     :param round_robin_size: continuous embedding size of a rank using round robin shard strategy
     :return: WholeMemoryEmbedding
     """
-    if optimizer is None:
-        wmb_optimizer = wmb.create_non_optimizer()
-    else:
-        wmb_optimizer = optimizer.wmb_opt
     if cache_policy is None:
         wmb_cache_policy = wmb.create_non_cache_policy()
     else:
@@ -448,16 +422,12 @@ def create_embedding(
             comm.wmb_comm,
             str_to_wmb_wholememory_memory_type(memory_type),
             str_to_wmb_wholememory_location(memory_location),
-            wmb_optimizer,
             wmb_cache_policy,
             user_defined_sms=gather_sms,
             round_robin_size=round_robin_size,
         ),
-        optimizer,
         cache_policy,
     )
-    if optimizer is not None:
-        optimizer.add_embedding(wm_embedding)
     if random_init is True:
         (
             local_tensor,
@@ -476,7 +446,6 @@ def create_embedding_from_filelist(
     dtype: torch.dtype,
     last_dim_size: int,
     *,
-    optimizer: Union[WholeMemoryOptimizer, None] = None,
     cache_policy: Union[WholeMemoryCachePolicy, None] = None,
     gather_sms: int = -1,
     round_robin_size: int = 0,
@@ -489,7 +458,6 @@ def create_embedding_from_filelist(
     :param filelist: list of files
     :param dtype: data type
     :param last_dim_size: size of last dim
-    :param optimizer: optimizer
     :param cache_policy: cache policy
     :param gather_sms: the number of SMs used in gather process
     :param round_robin_size: continuous embedding size of a rank using round robin shard strategy
@@ -516,7 +484,6 @@ def create_embedding_from_filelist(
         memory_location,
         dtype,
         [total_entry_count, last_dim_size],
-        optimizer=optimizer,
         cache_policy=cache_policy,
         gather_sms=gather_sms,
         round_robin_size=round_robin_size,
@@ -554,3 +521,35 @@ class WholeMemoryEmbeddingModule(torch.nn.Module):
             self.training,
             force_dtype,
         )
+
+
+def create_wholememory_optimizer(embeddings: Union[WholeMemoryEmbedding, List[WholeMemoryEmbedding]],
+                                 optimizer_type: str,
+                                 param_dict: dict):
+    """
+    Create WholeMemoryOptimizer.
+    :param embeddings: WholememoryEmbeddings to set the Optimizer
+    :param optimizer_type: Type of the Optimizer
+    :param param_dict: parameters of the optimizer
+    :return: WholeMemoryOptimizer
+    """
+    wm_optimizer = WholeMemoryOptimizer(get_global_communicator())
+    wm_optimizer.wmb_opt.create_optimizer(
+        str_to_wmb_wholememory_optimizer_type(optimizer_type), param_dict
+    )
+    if isinstance(embeddings, WholeMemoryEmbedding):
+        wm_optimizer.add_embedding(embeddings)
+    else:
+        for em in embeddings:
+            wm_optimizer.add_embedding(em)
+    return wm_optimizer
+
+
+def destroy_wholememory_optimizer(optimizer: WholeMemoryOptimizer):
+    """
+    Destroy WholeMemoryOptimizer
+    :param optimizer: WholeMemoryOptimizer to destroy
+    :return: None
+    """
+    optimizer.wmb_opt.destroy_optimizer()
+    optimizer.wmb_opt = None


### PR DESCRIPTION
This PR refactors the embedding creation interface, decoupling it from the optimizer dependency. Users now can designate the embeddings for optimization during optimizer initialization.
cpp:
```
wholememory_create_embedding(&wm_embedding, ...);
wholememory_create_embedding_optimizer(&optimizer, ...);
wholememory_embedding_set_optimizer(wm_embedding, optimizer);
```
python:
```
wm_embedding = wgth.create_embedding(...)
wm_optimizer = wgth.create_wholememory_optimizer(wm_embedding, "adam", {})
```