### PR TITLE
support different entry size for different ranks

### DIFF
--- a/cpp/bench/CMakeLists.txt
+++ b/cpp/bench/CMakeLists.txt
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -35,7 +35,9 @@ function(ConfigureBench)
             rmm::rmm
             pthread
     )
-
+    if(BUILD_WITH_NVSHMEM)
+        target_compile_definitions(${BENCH_NAME} PRIVATE WITH_NVSHMEM_SUPPORT)
+    endif()
     set_target_properties(
             ${BENCH_NAME}
             PROPERTIES # set target compile options

--- a/cpp/bench/common/wholegraph_benchmark.cpp
+++ b/cpp/bench/common/wholegraph_benchmark.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,6 +50,23 @@ void host_random_init_integer_indices(void* indices,
   } else {
     host_get_random_integer_indices<int64_t>(indices, indices_desc, max_indices);
   }
+}
+
+void host_random_partition(size_t* partition_sizes, size_t total_size, int partition_count)
+{
+  std::default_random_engine random_engine(0);
+  std::uniform_int_distribution<size_t> uniform(90, 100);
+  size_t acc_size   = 0;
+  size_t random_sum = 0;
+  for (int i = 0; i < partition_count; i++) {
+    partition_sizes[i] = (size_t)uniform(random_engine);
+    random_sum += partition_sizes[i];
+  }
+  for (int i = 0; i < partition_count; i++) {
+    partition_sizes[i] = (size_t)((partition_sizes[i] / (double)random_sum) * total_size);
+    acc_size += partition_sizes[i];
+  }
+  partition_sizes[0] += total_size - acc_size;
 }
 
 void MultiProcessMeasurePerformance(std::function<void()> run_fn,

--- a/cpp/bench/common/wholegraph_benchmark.hpp
+++ b/cpp/bench/common/wholegraph_benchmark.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,8 @@ namespace wholegraph::bench {
 void host_random_init_integer_indices(void* indices,
                                       wholememory_array_description_t indices_desc,
                                       int64_t max_indices);
+
+void host_random_partition(size_t* partition_sizes, size_t total_size, int partition_count);
 
 struct Metric {
   Metric(const std::string& metrics_name,

--- a/cpp/include/wholememory/device_reference.cuh
+++ b/cpp/include/wholememory/device_reference.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,23 +26,48 @@ class device_reference {
  public:
   __device__ __forceinline__ explicit device_reference(const wholememory_gref_t& gref)
     : pointer_(static_cast<DataTypeT*>(gref.pointer)),
-      typed_stride_(gref.stride / sizeof(DataTypeT))
+      typed_stride_(gref.stride / sizeof(DataTypeT)),
+      world_size_(gref.world_size),
+      same_chunk_(gref.same_chunk)
   {
     assert(gref.stride % sizeof(DataTypeT) == 0);
+    if (typed_stride_ != 0 && !same_chunk_) {
+      assert(world_size_ <= 8);  // intra-node WHOLEMEMORY_MT_CHUNKED
+      for (int i = 0; i < world_size_ + 1; i++) {
+        assert(gref.rank_memory_offsets[i] % sizeof(DataTypeT) == 0);
+        typed_rank_mem_offsets_[i] = gref.rank_memory_offsets[i] / sizeof(DataTypeT);
+      }
+    }
   }
   __device__ device_reference() = delete;
 
   __device__ __forceinline__ DataTypeT& operator[](size_t index)
   {
     if (typed_stride_ == 0) { return pointer_[index]; }
-    size_t rank = index / typed_stride_;
-    return static_cast<DataTypeT**>(
-      static_cast<void*>(pointer_))[rank][index - rank * typed_stride_];
+    if (same_chunk_) {
+      size_t rank = index / typed_stride_;
+      return static_cast<DataTypeT**>(
+        static_cast<void*>(pointer_))[rank][index - rank * typed_stride_];
+    } else {
+      size_t rank = 0;
+      for (int i = 1; i < world_size_ + 1; i++) {
+        if (index < typed_rank_mem_offsets_[i]) {
+          rank = i - 1;
+          break;
+        }
+      }
+      return static_cast<DataTypeT**>(
+        static_cast<void*>(pointer_))[rank][index - typed_rank_mem_offsets_[rank]];
+    }
   }
 
  private:
   DataTypeT* pointer_;
+  int world_size_;
   size_t typed_stride_;
+
+  bool same_chunk_;
+  size_t typed_rank_mem_offsets_[8 + 1];
 };
 
 }  // namespace wholememory

--- a/cpp/include/wholememory/embedding.h
+++ b/cpp/include/wholememory/embedding.h
@@ -129,6 +129,8 @@ wholememory_error_code_t wholememory_destroy_embedding_cache_policy(
  * @param memory_type : Memory Type of the underlying WholeMemory
  * @param memory_location : Memory Location of the underlying WholeMemory
  * @param cache_policy : Cache policy for this embedding, if don't use cache, use nullptr
+ * @param embedding_entry_partition: Embedding entry count of each rank, the length must be
+ * world_size
  * @param user_defined_sms : User-defined sms number for raw embedding gather/scatter
  * @param round_robin_size : continuous embedding size in each rank under round-robin shard mode
  * @return : wholememory_error_code_t
@@ -140,8 +142,9 @@ wholememory_error_code_t wholememory_create_embedding(
   wholememory_memory_type_t memory_type,
   wholememory_memory_location_t memory_location,
   wholememory_embedding_cache_policy_t cache_policy,
-  int user_defined_sms = -1,
-  int round_robin_size = 0);
+  size_t* embedding_entry_partition = nullptr,
+  int user_defined_sms              = -1,
+  int round_robin_size              = 0);
 
 /**
  * Destroy WholeMemory Embedding

--- a/cpp/include/wholememory/global_reference.h
+++ b/cpp/include/wholememory/global_reference.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,14 +24,18 @@ extern "C" {
 /**
  * @brief Global reference of a WholeMemory object
  *
- * A global reference is for Continuous of Chunked WholeMemory Type, in these types, each rank can
+ * A global reference is for Continuous or Chunked WholeMemory Type, in these types, each rank can
  * directly access all memory from all ranks. The global reference is used to do this direct access.
  */
 struct wholememory_gref_t {
   void* pointer; /*!< pointer to data for CONTINUOUS WholeMemory or pointer to data pointer array
                     for CHUNKED WholeMemory */
+  size_t*
+    rank_memory_offsets; /*!< memory offset of each rank, and the length must be world_size+1 */
+  int world_size;
   size_t
     stride; /*!< must be 0 for CONTINUOUS WholeMemory or memory size in byte for each pointer */
+  bool same_chunk; /*!< if true, rank can be got by offset/stride */
 };
 
 /**
@@ -43,9 +47,11 @@ wholememory_gref_t wholememory_create_continuous_global_reference(void* ptr);
 
 struct wholememory_nvshmem_ref_t {
   void* pointer;
+  size_t* rank_memory_offsets;
   size_t stride;
   int world_rank;
   int world_size;
+  bool same_chunk;
 };
 
 #ifdef __cplusplus

--- a/cpp/include/wholememory/wholememory.h
+++ b/cpp/include/wholememory/wholememory.h
@@ -238,6 +238,7 @@ typedef struct wholememory_handle_* wholememory_handle_t;
  * @param memory_type : WholeMemory type
  * @param memory_location : memory location, host or device
  * @param data_granularity : granularity size of data, which is guaranteed not to be partitioned.
+ * @param rank_entry_partition : entry count of each rank (size of entry equal to data_granularity)
  * @return : wholememory_error_code_t
  */
 wholememory_error_code_t wholememory_malloc(wholememory_handle_t* wholememory_handle_ptr,
@@ -245,7 +246,8 @@ wholememory_error_code_t wholememory_malloc(wholememory_handle_t* wholememory_ha
                                             wholememory_comm_t comm,
                                             wholememory_memory_type_t memory_type,
                                             wholememory_memory_location_t memory_location,
-                                            size_t data_granularity);
+                                            size_t data_granularity,
+                                            size_t* rank_entry_partition = nullptr);
 
 /**
  * Free allocated WholeMemory Handle
@@ -310,6 +312,24 @@ wholememory_error_code_t wholememory_get_local_memory(void** local_ptr,
                                                       wholememory_handle_t wholememory_handle);
 
 /**
+ * Get local memory size from WholeMemory Handle of current rank
+ * @param local_size : returned local memory size
+ * @param wholememory_handle : WholeMemory Handle
+ * @return : wholememory_error_code_t
+ */
+wholememory_error_code_t wholememory_get_local_size(size_t* local_size,
+                                                    wholememory_handle_t wholememory_handle);
+
+/**
+ * Get local memory offset from WholeMemory Handle of current rank
+ * @param local_offset : returned local memory offset
+ * @param wholememory_handle : WholeMemory Handle
+ * @return : wholememory_error_code_t
+ */
+wholememory_error_code_t wholememory_get_local_offset(size_t* local_offset,
+                                                      wholememory_handle_t wholememory_handle);
+
+/**
  * Get local memory of specified rank from WholeMemory Handle
  * @param rank_memory_ptr : returned local memory pointer of specified rank
  * @param rank_memory_size : returned local memory size of specified rank
@@ -323,6 +343,17 @@ wholememory_error_code_t wholememory_get_rank_memory(void** rank_memory_ptr,
                                                      size_t* rank_memory_offset,
                                                      int rank,
                                                      wholememory_handle_t wholememory_handle);
+
+/**
+ * Get the equal partition plan WholeMemory uses by default
+ * @param entry_per_rank : returned entry count per rank
+ * @param total_entry_count : total entry count
+ * @param world_size : communicator world size
+ * @return : wholememory_error_code_t
+ */
+wholememory_error_code_t wholememory_equal_entry_partition_plan(size_t* entry_per_rank,
+                                                                size_t total_entry_count,
+                                                                int world_size);
 
 /**
  * Get global memory pointer from WholeMemory Handle.
@@ -345,38 +376,22 @@ wholememory_error_code_t wholememory_get_global_reference(wholememory_gref_t* wh
                                                           wholememory_handle_t wholememory_handle);
 
 /**
- * Get the partition plan WholeMemory will use
- * @param size_per_rank : returned size per rank
- * @param total_size : total size
- * @param data_granularity : data granularity
- * @param world_size : communicator world size
- * @return : wholememory_error_code_t
- */
-wholememory_error_code_t wholememory_determine_partition_plan(size_t* size_per_rank,
-                                                              size_t total_size,
-                                                              size_t data_granularity,
-                                                              int world_size);
-
-/**
- * Get the partition plan WholeMemory will use based on entry count.
- * Entry is number of data granularity
- * @param entry_per_rank : returned entry count per rank
- * @param total_entry_count : total entry count
- * @param world_size : communicator world size
- * @return : wholememory_error_code_t
- */
-wholememory_error_code_t wholememory_determine_entry_partition_plan(size_t* entry_per_rank,
-                                                                    size_t total_entry_count,
-                                                                    int world_size);
-
-/**
- * Get the partition plan used in WholeMemory Handle
- * @param size_per_rank : returned size per rank
+ * Get memory size of each rank from WholeMemory Handle
+ * @param rank_mem_sizes : returned memory size of each rank
  * @param wholememory_handle : WholeMemory Handle
  * @return : wholememory_error_code_t
  */
-wholememory_error_code_t wholememory_get_partition_plan(size_t* size_per_rank,
-                                                        wholememory_handle_t wholememory_handle);
+wholememory_error_code_t wholememory_get_rank_partition_sizes(
+  size_t* rank_mem_sizes, wholememory_handle_t wholememory_handle);
+
+/**
+ * Get memory offset of each rank from WholeMemory Handle
+ * @param rank_mem_offsets : returned memory offset of each rank
+ * @param wholememory_handle : WholeMemory Handle
+ * @return : wholememory_error_code_t
+ */
+wholememory_error_code_t wholememory_get_rank_partition_offsets(
+  size_t* rank_mem_offsets, wholememory_handle_t wholememory_handle);
 
 /**
  * Fork a new process and get device count. Should be called before other CUDA call

--- a/cpp/include/wholememory/wholememory_tensor.h
+++ b/cpp/include/wholememory/wholememory_tensor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,6 +37,7 @@ typedef struct wholememory_tensor_* wholememory_tensor_t;
  * @param comm : WholeMemory Communicator
  * @param memory_type : Memory Type of the underlying WholeMemory
  * @param memory_location : Memory Location of the underlying WholeMemory
+ * @param tensor_entry_partition : Tensor entry count of each rank, the length must be world_size.
  * @return : wholememory_error_code_t
  */
 wholememory_error_code_t wholememory_create_tensor(
@@ -44,7 +45,8 @@ wholememory_error_code_t wholememory_create_tensor(
   wholememory_tensor_description_t* tensor_description,
   wholememory_comm_t comm,
   wholememory_memory_type_t memory_type,
-  wholememory_memory_location_t memory_location);
+  wholememory_memory_location_t memory_location,
+  size_t* tensor_entry_partition = nullptr);
 
 /**
  * Destroy WholeMemory Tensor
@@ -131,11 +133,40 @@ wholememory_error_code_t wholememory_tensor_map_local_tensor(
 void* wholememory_tensor_get_data_pointer(wholememory_tensor_t wholememory_tensor);
 
 /**
- * Get entry count per rank of a WholeMemory Tensor
+ * Get entry offset of each rank from WholeMemory Tensor
+ * @param entry_offsets : returned entry offset of each rank
  * @param wholememory_tensor : WholeMemory Tensor
- * @return : entry count per rank
+ * @return : wholememory_error_code_t
  */
-size_t wholememory_tensor_get_entry_per_partition(wholememory_tensor_t wholememory_tensor);
+wholememory_error_code_t wholememory_tensor_get_entry_offsets(
+  size_t* entry_offsets, wholememory_tensor_t wholememory_tensor);
+
+/**
+ * Get entry count of each rank from WholeMemory Tensor
+ * @param entry_offsets : returned entry count of each rank
+ * @param wholememory_tensor : WholeMemory Tensor
+ * @return : wholememory_error_code_t
+ */
+wholememory_error_code_t wholememory_tensor_get_entry_partition_sizes(
+  size_t* entry_partition, wholememory_tensor_t wholememory_tensor);
+
+/**
+ * Get entry count of current rank from WholeMemory Tensor
+ * @param local_entry_count  : returned entry count of current rank
+ * @param wholememory_tensor : WholeMemory Tensor
+ * @return : wholememory_error_code_t
+ */
+wholememory_error_code_t wholememory_tensor_get_local_entry_count(
+  size_t* local_entry_count, wholememory_tensor_t wholememory_tensor);
+
+/**
+ * Get entry start of current rank from WholeMemory Tensor
+ * @param local_entry_start  : returned entry start id of current rank
+ * @param wholememory_tensor : WholeMemory Tensor
+ * @return : wholememory_error_code_t
+ */
+wholememory_error_code_t wholememory_tensor_get_local_entry_start(
+  size_t* local_entry_start, wholememory_tensor_t wholememory_tensor);
 
 /**
  * Get sub tensor of a WholeMemory Tensor

--- a/cpp/include/wholememory/wholememory_tensor.h
+++ b/cpp/include/wholememory/wholememory_tensor.h
@@ -143,7 +143,7 @@ wholememory_error_code_t wholememory_tensor_get_entry_offsets(
 
 /**
  * Get entry count of each rank from WholeMemory Tensor
- * @param entry_offsets : returned entry count of each rank
+ * @param entry_partition : returned entry count of each rank
  * @param wholememory_tensor : WholeMemory Tensor
  * @return : wholememory_error_code_t
  */

--- a/cpp/src/wholememory/embedding.hpp
+++ b/cpp/src/wholememory/embedding.hpp
@@ -45,7 +45,8 @@ class embedding_base : public wholememory_embedding_ {
                                     wholememory_comm_t comm,
                                     wholememory_memory_type_t memory_type,
                                     wholememory_memory_location_t memory_location,
-                                    wholememory_embedding_cache_policy_t policy) noexcept;
+                                    wholememory_embedding_cache_policy_t policy,
+                                    size_t* embedding_entry_partition) noexcept;
   void deallocate() noexcept;
   virtual wholememory_error_code_t gather(wholememory_tensor_t indices,
                                           wholememory_tensor_t output,

--- a/cpp/src/wholememory/memory_handle.hpp
+++ b/cpp/src/wholememory/memory_handle.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,7 +40,8 @@ wholememory_error_code_t create_wholememory(wholememory_handle_t* wholememory_ha
                                             wholememory_comm_t comm,
                                             wholememory_memory_type_t memory_type,
                                             wholememory_memory_location_t memory_location,
-                                            size_t data_granularity) noexcept;
+                                            size_t data_granularity,
+                                            size_t* rank_entry_partition = nullptr) noexcept;
 
 wholememory_error_code_t destroy_wholememory_with_comm_locked(
   wholememory_handle_t wholememory_handle) noexcept;
@@ -71,21 +72,27 @@ wholememory_error_code_t get_rank_memory_from_handle(
   int rank,
   wholememory_handle_t wholememory_handle) noexcept;
 
+wholememory_error_code_t get_local_size_from_handle(
+  size_t* size, wholememory_handle_t wholememory_handle) noexcept;
+
+wholememory_error_code_t get_local_offset_from_handle(
+  size_t* offset, wholememory_handle_t wholememory_handle) noexcept;
+
 wholememory_error_code_t get_global_pointer_from_handle(
   void** global_ptr, wholememory_handle_t wholememory_handle) noexcept;
 
 wholememory_error_code_t get_global_reference_from_handle(
   wholememory_gref_t* wholememory_gref, wholememory_handle_t wholememory_handle) noexcept;
 
-wholememory_error_code_t determine_partition_plan(size_t* size_per_rank,
-                                                  size_t total_size,
-                                                  size_t data_granularity,
-                                                  int world_size) noexcept;
+wholememory_error_code_t equal_partition_plan(size_t* entry_per_rank,
+                                              size_t total_entry_count,
+                                              int world_size) noexcept;
 
-size_t determine_entry_partition_plan(size_t total_entry_count, int world_size) noexcept;
+wholememory_error_code_t get_rank_partition_sizes_from_handle(
+  size_t* rank_sizes, wholememory_handle_t wholememory_handle) noexcept;
 
-wholememory_error_code_t get_partition_plan_from_handle(
-  size_t* size_per_rank, wholememory_handle_t wholememory_handle) noexcept;
+wholememory_error_code_t get_rank_partition_offsets_from_handle(
+  size_t* rank_offsets, wholememory_handle_t wholememory_handle) noexcept;
 
 wholememory_distributed_backend_t get_distributed_backend_t(
   wholememory_handle_t wholememory_handle) noexcept;

--- a/cpp/src/wholememory/wholememory.cpp
+++ b/cpp/src/wholememory/wholememory.cpp
@@ -107,10 +107,16 @@ wholememory_error_code_t wholememory_malloc(wholememory_handle_t* wholememory_ha
                                             wholememory_comm_t comm,
                                             wholememory_memory_type_t memory_type,
                                             wholememory_memory_location_t memory_location,
-                                            size_t data_granularity)
+                                            size_t data_granularity,
+                                            size_t* rank_entry_partition)
 {
-  return wholememory::create_wholememory(
-    wholememory_handle_ptr, total_size, comm, memory_type, memory_location, data_granularity);
+  return wholememory::create_wholememory(wholememory_handle_ptr,
+                                         total_size,
+                                         comm,
+                                         memory_type,
+                                         memory_location,
+                                         data_granularity,
+                                         rank_entry_partition);
 }
 
 wholememory_error_code_t wholememory_free(wholememory_handle_t wholememory_handle)
@@ -170,6 +176,13 @@ wholememory_error_code_t wholememory_get_rank_memory(void** rank_memory_ptr,
     rank_memory_ptr, rank_memory_size, rank_memory_offset, rank, wholememory_handle);
 }
 
+wholememory_error_code_t wholememory_equal_entry_partition_plan(size_t* entry_per_rank,
+                                                                size_t total_entry_count,
+                                                                int world_size)
+{
+  return wholememory::equal_partition_plan(entry_per_rank, total_entry_count, world_size);
+}
+
 wholememory_error_code_t wholememory_get_global_pointer(void** global_ptr,
                                                         wholememory_handle_t wholememory_handle)
 {
@@ -193,28 +206,28 @@ wholememory_error_code_t wholememory_get_nvshmem_reference(
 
 #endif
 
-wholememory_error_code_t wholememory_determine_partition_plan(size_t* size_per_rank,
-                                                              size_t total_size,
-                                                              size_t data_granularity,
-                                                              int world_size)
+wholememory_error_code_t wholememory_get_rank_partition_sizes(
+  size_t* rank_sizes, wholememory_handle_t wholememory_handle)
 {
-  return wholememory::determine_partition_plan(
-    size_per_rank, total_size, data_granularity, world_size);
+  return wholememory::get_rank_partition_sizes_from_handle(rank_sizes, wholememory_handle);
 }
 
-wholememory_error_code_t wholememory_determine_entry_partition_plan(size_t* entry_per_rank,
-                                                                    size_t total_entry_count,
-                                                                    int world_size)
+wholememory_error_code_t wholememory_get_rank_partition_offsets(
+  size_t* rank_offsets, wholememory_handle_t wholememory_handle)
 {
-  if (entry_per_rank == nullptr) { return WHOLEMEMORY_INVALID_INPUT; }
-  *entry_per_rank = wholememory::determine_entry_partition_plan(total_entry_count, world_size);
-  return WHOLEMEMORY_SUCCESS;
+  return wholememory::get_rank_partition_offsets_from_handle(rank_offsets, wholememory_handle);
 }
 
-wholememory_error_code_t wholememory_get_partition_plan(size_t* size_per_rank,
-                                                        wholememory_handle_t wholememory_handle)
+wholememory_error_code_t wholememory_get_local_size(size_t* local_size,
+                                                    wholememory_handle_t wholememory_handle)
 {
-  return wholememory::get_partition_plan_from_handle(size_per_rank, wholememory_handle);
+  return wholememory::get_local_size_from_handle(local_size, wholememory_handle);
+}
+
+wholememory_error_code_t wholememory_get_local_offset(size_t* local_size,
+                                                      wholememory_handle_t wholememory_handle)
+{
+  return wholememory::get_local_offset_from_handle(local_size, wholememory_handle);
 }
 
 int fork_get_device_count()

--- a/cpp/src/wholememory_ops/functions/bucket_ids_func.cu
+++ b/cpp/src/wholememory_ops/functions/bucket_ids_func.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,22 +29,49 @@
 namespace wholememory_ops {
 
 template <typename IndexT>
+__device__ __forceinline__ int dest_rank(IndexT entry_idx,
+                                         size_t total_entry_count,
+                                         const size_t* embedding_entry_offsets,
+                                         int world_size)
+{
+  size_t estimated_entry_per_rank = total_entry_count / world_size;
+  int estimated_rank              = max(world_size - 1, int(entry_idx / estimated_entry_per_rank));
+  if (embedding_entry_offsets[estimated_rank] > entry_idx) {
+    for (int i = estimated_rank - 1; i >= 0; i--) {
+      if (embedding_entry_offsets[i] <= entry_idx) { return i; }
+    }
+  } else {
+    for (int i = estimated_rank + 1; i <= world_size; i++) {
+      if (embedding_entry_offsets[i] > entry_idx) { return i - 1; }
+    }
+  }
+  return 0;
+}
+
+template <typename IndexT>
 __global__ void bucket_ids_for_ranks_kernel(const IndexT* indices,
                                             size_t indice_count,
                                             int64_t* dev_rank_id_count_ptr,
-                                            size_t embedding_entry_count_per_rank,
+                                            size_t* embedding_entry_offsets,
                                             int world_size)
 {
-  extern __shared__ int rank_count_shared[];
+  extern __shared__ char shmem[];
+  int* rank_count_shared = reinterpret_cast<int*>(shmem);
   for (int idx = threadIdx.x; idx < world_size; idx += blockDim.x) {
     rank_count_shared[idx] = 0;
   }
+  size_t* embedding_entry_offsets_shared =
+    reinterpret_cast<size_t*>(shmem + sizeof(size_t) * world_size);
+  for (int idx = threadIdx.x; idx < world_size + 1; idx += blockDim.x) {
+    embedding_entry_offsets_shared[idx] = embedding_entry_offsets[idx];
+  }
   __syncthreads();
+  size_t total_entry_count = embedding_entry_offsets_shared[world_size];
   for (int idx = threadIdx.x + blockIdx.x * blockDim.x; idx < indice_count;
        idx += blockDim.x * gridDim.x) {
     IndexT node_idx = indices[idx];
     if (node_idx < 0) continue;
-    int rank = node_idx / embedding_entry_count_per_rank;
+    int rank = dest_rank(node_idx, total_entry_count, embedding_entry_offsets_shared, world_size);
     assert(rank >= 0 && rank < world_size);
 #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 700
     atomicAdd_block(&rank_count_shared[rank], 1);
@@ -63,7 +90,7 @@ template <typename IndexT>
 void bucket_ids_for_ranks_temp_fn(void* indices,
                                   wholememory_array_description_t indice_desc,
                                   int64_t* dev_rank_id_count_ptr,
-                                  size_t embedding_entry_count_per_rank,
+                                  size_t* embedding_entry_offsets,
                                   int world_size,
                                   int sm_count,
                                   cudaStream_t stream)
@@ -73,12 +100,11 @@ void bucket_ids_for_ranks_temp_fn(void* indices,
   block_count         = std::min(block_count, sm_count * 4);
   IndexT* indices_ptr = static_cast<IndexT*>(indices);
   indices_ptr += indice_desc.storage_offset;
-  bucket_ids_for_ranks_kernel<<<block_count, BLOCK_SIZE, sizeof(int) * world_size, stream>>>(
-    indices_ptr,
-    indice_desc.size,
-    dev_rank_id_count_ptr,
-    embedding_entry_count_per_rank,
-    world_size);
+  bucket_ids_for_ranks_kernel<<<block_count,
+                                BLOCK_SIZE,
+                                sizeof(size_t) * (world_size * 2 + 1),
+                                stream>>>(
+    indices_ptr, indice_desc.size, dev_rank_id_count_ptr, embedding_entry_offsets, world_size);
 }
 
 REGISTER_DISPATCH_ONE_TYPE(BucketIdForRanks, bucket_ids_for_ranks_temp_fn, SINT3264)
@@ -86,7 +112,7 @@ REGISTER_DISPATCH_ONE_TYPE(BucketIdForRanks, bucket_ids_for_ranks_temp_fn, SINT3
 wholememory_error_code_t bucket_ids_for_ranks(void* indices,
                                               wholememory_array_description_t indice_desc,
                                               int64_t* dev_rank_id_count_ptr,
-                                              size_t embedding_entry_count_per_rank,
+                                              size_t* embedding_entry_offsets,
                                               int world_size,
                                               cudaDeviceProp* prop,
                                               cudaStream_t stream)
@@ -101,7 +127,7 @@ wholememory_error_code_t bucket_ids_for_ranks(void* indices,
                       indices,
                       indice_desc,
                       dev_rank_id_count_ptr,
-                      embedding_entry_count_per_rank,
+                      embedding_entry_offsets,
                       world_size,
                       sm_count,
                       stream);

--- a/cpp/src/wholememory_ops/functions/bucket_ids_func.h
+++ b/cpp/src/wholememory_ops/functions/bucket_ids_func.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ namespace wholememory_ops {
 wholememory_error_code_t bucket_ids_for_ranks(void* indices,
                                               wholememory_array_description_t indice_desc,
                                               int64_t* dev_rank_id_count_ptr,
-                                              size_t embedding_entry_count_per_rank,
+                                              size_t* embedding_entry_offsets,
                                               int world_size,
                                               cudaDeviceProp* prop,
                                               cudaStream_t stream);

--- a/cpp/src/wholememory_ops/functions/embedding_cache_func.h
+++ b/cpp/src/wholememory_ops/functions/embedding_cache_func.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -67,7 +67,7 @@ wholememory_error_code_t update_cache_different_comm(
   wholememory_array_description_t indice_desc,
   wholememory_tensor_t wm_raw_memory_embedding,
   wholememory_comm_t cache_comm,
-  size_t embedding_entry_count_per_cache_rank,
+  size_t* embedding_entry_offsets,
   const wholememory::embedding_cache_local_data* cache_local_data,
   int cache_set_coverage,
   wholememory_env_func_t* p_env_fns,

--- a/cpp/src/wholememory_ops/functions/embedding_cache_func.h
+++ b/cpp/src/wholememory_ops/functions/embedding_cache_func.h
@@ -55,7 +55,7 @@ wholememory_error_code_t update_cache_direct_same_comm(
  * @param wm_raw_memory_embedding : the WholeMemory Tensor that is to be cached which stores all
  * embeddings.
  * @param cache_comm : communicator of cache
- * @param embedding_entry_count_per_cache_rank : embedding entries covered by each cache rank
+ * @param embedding_entry_offsets : embedding entry offset of each cache rank
  * @param cache_local_data : embedding_cache_local_data of wm_raw_memory_embedding
  * @param cache_set_coverage : cache set coverage
  * @param p_env_fns : env fns

--- a/cpp/src/wholememory_ops/functions/exchange_ids_nccl_func.cu
+++ b/cpp/src/wholememory_ops/functions/exchange_ids_nccl_func.cu
@@ -161,7 +161,7 @@ wholememory_error_code_t bucket_and_exchange_ids_func(
   int64_t* host_rank_id_count_ptr,
   temp_memory_handle* dev_recv_indices_buffer_handle,
   int64_t* dev_raw_indice_ptr,
-  size_t embedding_entry_count_per_rank,
+  size_t* embedding_entry_offsets,
   wholememory_comm_t wm_comm,
   wm_thrust_allocator* p_thrust_allocator,
   wholememory_env_func_t* p_env_fns,
@@ -178,7 +178,7 @@ wholememory_error_code_t bucket_and_exchange_ids_func(
   WHOLEMEMORY_RETURN_ON_FAIL(bucket_ids_for_ranks(indices,
                                                   indice_desc,
                                                   dev_rank_id_count_ptr,
-                                                  embedding_entry_count_per_rank,
+                                                  embedding_entry_offsets,
                                                   world_size,
                                                   get_device_prop(-1),
                                                   stream));

--- a/cpp/src/wholememory_ops/functions/exchange_ids_nccl_func.h
+++ b/cpp/src/wholememory_ops/functions/exchange_ids_nccl_func.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ namespace wholememory_ops {
  * @param dev_recv_indices_buffer_handle : temp_memory_handle to create buffer for received indices.
  * @param dev_raw_indice_ptr : pointer to allocated int64_t array to storage raw indices mapping of
  * sort
- * @param embedding_entry_count_per_rank : entry count of embedding count per rank
+ * @param embedding_entry_offsets : embedding entry offsets
  * @param wm_comm : WholeMemory Communicator
  * @param p_thrust_allocator : thrust allocator
  * @param p_env_fns : EnvFns
@@ -48,7 +48,7 @@ wholememory_error_code_t bucket_and_exchange_ids_func(
   int64_t* host_rank_id_count_ptr,
   temp_memory_handle* dev_recv_indices_buffer_handle,
   int64_t* dev_raw_indice_ptr,
-  size_t embedding_entry_count_per_rank,
+  size_t* embedding_entry_offsets,
   wholememory_comm_t wm_comm,
   wm_thrust_allocator* p_thrust_allocator,
   wholememory_env_func_t* p_env_fns,

--- a/cpp/src/wholememory_ops/functions/nvshmem_device_reference.cuh
+++ b/cpp/src/wholememory_ops/functions/nvshmem_device_reference.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,41 +27,107 @@ class nvshmem_device_reference {
   __device__ __forceinline__ explicit nvshmem_device_reference(
     const wholememory_nvshmem_ref_t& nvshmem_ref)
     : pointer_(static_cast<DataTypeT*>(nvshmem_ref.pointer)),
-      typed_stride_(nvshmem_ref.stride / sizeof(DataTypeT))
+      typed_stride_(nvshmem_ref.stride / sizeof(DataTypeT)),
+      rank_memory_offsets_(nvshmem_ref.rank_memory_offsets),
+      world_size_(nvshmem_ref.world_size),
+      same_chunk_(nvshmem_ref.same_chunk)
   {
     assert(nvshmem_ref.stride % sizeof(DataTypeT) == 0);
+    if (!same_chunk_) {
+      estimated_stride_ = rank_memory_offsets_[world_size_] / world_size_;
+      cache_rank_       = 0;
+      cache_offset_     = 0;
+      cache_size_       = rank_memory_offsets_[1] - rank_memory_offsets_[0];
+    }
   }
 
   __device__ nvshmem_device_reference() = delete;
 
   __device__ __forceinline__ DataTypeT load(size_t index)
   {
-    size_t rank = index / typed_stride_;
-
-    return nvshmem_get<DataTypeT>(pointer_ + index - rank * typed_stride_, rank);
+    size_t rank = dest_rank(index);
+    if (same_chunk_)
+      return nvshmem_get<DataTypeT>(pointer_ + index - rank * typed_stride_, rank);
+    else
+      return nvshmem_get<DataTypeT>(
+        pointer_ + index - rank_memory_offsets_[rank] / sizeof(DataTypeT), rank);
   }
 
   __device__ __forceinline__ void store(size_t index, DataTypeT val)
   {
-    size_t rank = index / typed_stride_;
-    return nvshmem_put<DataTypeT>(pointer_ + index - rank * typed_stride_, val, rank);
+    size_t rank = dest_rank(index);
+    if (same_chunk_)
+      return nvshmem_put<DataTypeT>(pointer_ + index - rank * typed_stride_, rank);
+    else
+      return nvshmem_put<DataTypeT>(
+        pointer_ + index - rank_memory_offsets_[rank] / sizeof(DataTypeT), val, rank);
   }
 
   __device__ __forceinline__ DataTypeT* symmetric_address(size_t index)
   {
-    size_t rank = index / typed_stride_;
-    return pointer_ + index - rank * typed_stride_;
+    size_t rank = dest_rank(index);
+    if (same_chunk_)
+      return pointer_ + index - rank * typed_stride_;
+    else
+      return pointer_ + index - rank_memory_offsets_[rank] / sizeof(DataTypeT);
+  }
+
+  __device__ __forceinline__ void mov_offsets_to_shmem(char* shmem)
+  {
+    if (same_chunk_) return;
+    size_t* shmem_offsets = reinterpret_cast<size_t*>(shmem);
+    for (int i = threadIdx.x; i <= world_size_; i += blockDim.x) {
+      shmem_offsets[i] = rank_memory_offsets_[i];
+    }
+    __syncthreads();
+    rank_memory_offsets_ = shmem_offsets;
   }
 
   __device__ __forceinline__ size_t dest_rank(size_t index)
   {
-    size_t rank = index / typed_stride_;
-    return rank;
+    if (same_chunk_) {
+      return index / typed_stride_;
+    } else {
+      size_t rank   = 0;
+      size_t offset = index * sizeof(DataTypeT);
+      if (offset >= cache_offset_ && offset < cache_offset_ + cache_size_) {
+        rank = cache_rank_;
+      } else {
+        int estimated_rank = max(world_size_ - 1, int(offset / estimated_stride_));
+        if (rank_memory_offsets_[estimated_rank] > offset) {
+          for (int i = estimated_rank - 1; i >= 0; i--) {
+            if (rank_memory_offsets_[i] <= offset) {
+              rank = i;
+              break;
+            }
+          }
+        } else {
+          for (int i = estimated_rank + 1; i <= world_size_; i++) {
+            if (rank_memory_offsets_[i] > offset) {
+              rank = i - 1;
+              break;
+            }
+          }
+        }
+        cache_rank_   = rank;
+        cache_offset_ = rank_memory_offsets_[rank];
+        cache_size_   = rank_memory_offsets_[rank + 1] - rank_memory_offsets_[rank];
+      }
+      return rank;
+    }
   }
 
  private:
   DataTypeT* pointer_;
   size_t typed_stride_;
+  size_t* rank_memory_offsets_;
+  int world_size_;
+
+  size_t estimated_stride_;
+  bool same_chunk_;
+  int cache_rank_;
+  size_t cache_offset_;
+  size_t cache_size_;
 };
 }  // namespace wholememory_ops
 

--- a/cpp/src/wholememory_ops/functions/nvshmem_gather_func_impl_floating_data_int32_indices.cu
+++ b/cpp/src/wholememory_ops/functions/nvshmem_gather_func_impl_floating_data_int32_indices.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,24 +31,23 @@ void nvshmem_gather_floating_int32_temp_func(wholememory_comm_t wm_comm,
                                              void* output,
                                              void* temp_output,
                                              wholememory_matrix_description_t output_desc,
-                                             size_t embedding_entry_count_per_rank,
+                                             size_t* embedding_entry_offsets,
                                              wholememory_env_func_t* p_env_fns,
                                              cudaStream_t stream,
                                              int gather_sms)
 {
-  nvshmem_gather_temp_get_mem_sort_idx_func<EmbeddingT, int32_t, OutputT>(
-    wm_comm,
-    embeding_nvshmem_ptr,
-    embedding_desc,
-    indices,
-    indice_count,
-    output,
-    temp_output,
-    output_desc,
-    embedding_entry_count_per_rank,
-    p_env_fns,
-    stream,
-    gather_sms);
+  nvshmem_gather_temp_get_mem_sort_idx_func<EmbeddingT, int32_t, OutputT>(wm_comm,
+                                                                          embeding_nvshmem_ptr,
+                                                                          embedding_desc,
+                                                                          indices,
+                                                                          indice_count,
+                                                                          output,
+                                                                          temp_output,
+                                                                          output_desc,
+                                                                          embedding_entry_offsets,
+                                                                          p_env_fns,
+                                                                          stream,
+                                                                          gather_sms);
 }
 
 REGISTER_DISPATCH_TWO_TYPES(NvshmemGatherFuncFloatingInt32,
@@ -65,7 +64,7 @@ wholememory_error_code_t nvshmem_gather_floating_int32_func(
   void* output,
   void* temp_output,
   wholememory_matrix_description_t output_desc,
-  size_t embedding_entry_count_per_rank,
+  size_t* embedding_entry_offsets,
   wholememory_env_func_t* p_env_fns,
   cudaStream_t stream,
   int gather_sms)
@@ -86,7 +85,7 @@ wholememory_error_code_t nvshmem_gather_floating_int32_func(
                        output,
                        temp_output,
                        output_desc,
-                       embedding_entry_count_per_rank,
+                       embedding_entry_offsets,
                        p_env_fns,
                        stream,
                        gather_sms);

--- a/cpp/src/wholememory_ops/functions/nvshmem_gather_func_impl_floating_data_int64_indices.cu
+++ b/cpp/src/wholememory_ops/functions/nvshmem_gather_func_impl_floating_data_int64_indices.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,24 +31,23 @@ void nvshmem_gather_floating_int64_temp_func(wholememory_comm_t wm_comm,
                                              void* output,
                                              void* temp_output,
                                              wholememory_matrix_description_t output_desc,
-                                             size_t embedding_entry_count_per_rank,
+                                             size_t* embedding_entry_offsets,
                                              wholememory_env_func_t* p_env_fns,
                                              cudaStream_t stream,
                                              int gather_sms)
 {
-  nvshmem_gather_temp_get_mem_sort_idx_func<EmbeddingT, int64_t, OutputT>(
-    wm_comm,
-    embeding_nvshmem_ptr,
-    embedding_desc,
-    indices,
-    indice_count,
-    output,
-    temp_output,
-    output_desc,
-    embedding_entry_count_per_rank,
-    p_env_fns,
-    stream,
-    gather_sms);
+  nvshmem_gather_temp_get_mem_sort_idx_func<EmbeddingT, int64_t, OutputT>(wm_comm,
+                                                                          embeding_nvshmem_ptr,
+                                                                          embedding_desc,
+                                                                          indices,
+                                                                          indice_count,
+                                                                          output,
+                                                                          temp_output,
+                                                                          output_desc,
+                                                                          embedding_entry_offsets,
+                                                                          p_env_fns,
+                                                                          stream,
+                                                                          gather_sms);
 }
 
 REGISTER_DISPATCH_TWO_TYPES(NvshmemGatherFuncFloatingInt64,
@@ -65,7 +64,7 @@ wholememory_error_code_t nvshmem_gather_floating_int64_func(
   void* output,
   void* temp_output,
   wholememory_matrix_description_t output_desc,
-  size_t embedding_entry_count_per_rank,
+  size_t* embedding_entry_offsets,
   wholememory_env_func_t* p_env_fns,
   cudaStream_t stream,
   int gather_sms)
@@ -86,7 +85,7 @@ wholememory_error_code_t nvshmem_gather_floating_int64_func(
                        output,
                        temp_output,
                        output_desc,
-                       embedding_entry_count_per_rank,
+                       embedding_entry_offsets,
                        p_env_fns,
                        stream,
                        gather_sms);

--- a/cpp/src/wholememory_ops/functions/nvshmem_gather_func_impl_integer_data_int32_indices.cu
+++ b/cpp/src/wholememory_ops/functions/nvshmem_gather_func_impl_integer_data_int32_indices.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,24 +31,23 @@ void nvshmem_gather_integer_int32_temp_func(wholememory_comm_t wm_comm,
                                             void* output,
                                             void* temp_output,
                                             wholememory_matrix_description_t output_desc,
-                                            size_t embedding_entry_count_per_rank,
+                                            size_t* embedding_entry_offsets,
                                             wholememory_env_func_t* p_env_fns,
                                             cudaStream_t stream,
                                             int gather_sms)
 {
-  nvshmem_gather_temp_get_mem_sort_idx_func<EmbeddingT, int32_t, OutputT>(
-    wm_comm,
-    embeding_nvshmem_ptr,
-    embedding_desc,
-    indices,
-    indice_count,
-    output,
-    temp_output,
-    output_desc,
-    embedding_entry_count_per_rank,
-    p_env_fns,
-    stream,
-    gather_sms);
+  nvshmem_gather_temp_get_mem_sort_idx_func<EmbeddingT, int32_t, OutputT>(wm_comm,
+                                                                          embeding_nvshmem_ptr,
+                                                                          embedding_desc,
+                                                                          indices,
+                                                                          indice_count,
+                                                                          output,
+                                                                          temp_output,
+                                                                          output_desc,
+                                                                          embedding_entry_offsets,
+                                                                          p_env_fns,
+                                                                          stream,
+                                                                          gather_sms);
 }
 
 REGISTER_DISPATCH_TWO_TYPES(NvshmemGatherFuncIntegerInt32,
@@ -65,7 +64,7 @@ wholememory_error_code_t nvshmem_gather_integer_int32_func(
   void* output,
   void* temp_output,
   wholememory_matrix_description_t output_desc,
-  size_t embedding_entry_count_per_rank,
+  size_t* embedding_entry_offsets,
   wholememory_env_func_t* p_env_fns,
   cudaStream_t stream,
   int gather_sms)
@@ -86,7 +85,7 @@ wholememory_error_code_t nvshmem_gather_integer_int32_func(
                        output,
                        temp_output,
                        output_desc,
-                       embedding_entry_count_per_rank,
+                       embedding_entry_offsets,
                        p_env_fns,
                        stream,
                        gather_sms);

--- a/cpp/src/wholememory_ops/functions/nvshmem_gather_func_impl_integer_data_int64_indices.cu
+++ b/cpp/src/wholememory_ops/functions/nvshmem_gather_func_impl_integer_data_int64_indices.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,24 +31,23 @@ void nvshmem_gather_integer_int64_temp_func(wholememory_comm_t wm_comm,
                                             void* output,
                                             void* temp_output,
                                             wholememory_matrix_description_t output_desc,
-                                            size_t embedding_entry_count_per_rank,
+                                            size_t* embedding_entry_offsets,
                                             wholememory_env_func_t* p_env_fns,
                                             cudaStream_t stream,
                                             int gather_sms)
 {
-  nvshmem_gather_temp_get_mem_sort_idx_func<EmbeddingT, int64_t, OutputT>(
-    wm_comm,
-    embeding_nvshmem_ptr,
-    embedding_desc,
-    indices,
-    indice_count,
-    output,
-    temp_output,
-    output_desc,
-    embedding_entry_count_per_rank,
-    p_env_fns,
-    stream,
-    gather_sms);
+  nvshmem_gather_temp_get_mem_sort_idx_func<EmbeddingT, int64_t, OutputT>(wm_comm,
+                                                                          embeding_nvshmem_ptr,
+                                                                          embedding_desc,
+                                                                          indices,
+                                                                          indice_count,
+                                                                          output,
+                                                                          temp_output,
+                                                                          output_desc,
+                                                                          embedding_entry_offsets,
+                                                                          p_env_fns,
+                                                                          stream,
+                                                                          gather_sms);
 }
 
 REGISTER_DISPATCH_TWO_TYPES(NvshmemGatherFuncIntegerInt64,
@@ -65,7 +64,7 @@ wholememory_error_code_t nvshmem_gather_integer_int64_func(
   void* output,
   void* temp_output,
   wholememory_matrix_description_t output_desc,
-  size_t embedding_entry_count_per_rank,
+  size_t* embedding_entry_offsets,
   wholememory_env_func_t* p_env_fns,
   cudaStream_t stream,
   int gather_sms)
@@ -86,7 +85,7 @@ wholememory_error_code_t nvshmem_gather_integer_int64_func(
                        output,
                        temp_output,
                        output_desc,
-                       embedding_entry_count_per_rank,
+                       embedding_entry_offsets,
                        p_env_fns,
                        stream,
                        gather_sms);
@@ -113,7 +112,7 @@ __global__ void scatter_func_with_nvshmem_sort_idxs_kernel<float, int>(
   const int max_blocks_for_local,
   const int intra_node_ranks,
   const int node_rank,
-  size_t embedding_entry_per_rank,
+  size_t* embedding_entry_offsets,
   const int threads_per_group);
 };  // namespace wholememory_ops
 

--- a/cpp/src/wholememory_ops/functions/nvshmem_scatter_func_impl_floating_data_int32_indices.cu
+++ b/cpp/src/wholememory_ops/functions/nvshmem_scatter_func_impl_floating_data_int32_indices.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,24 +31,23 @@ void nvshmem_scatter_floating_int32_temp_func(wholememory_comm_t wm_comm,
                                               int64_t indice_count,
                                               wholememory_nvshmem_ref_t embeding_nvshmem_ptr,
                                               wholememory_matrix_description_t embedding_desc,
-                                              size_t embedding_entry_count_per_rank,
+                                              size_t* embedding_entry_offsets,
                                               wholememory_env_func_t* p_env_fns,
                                               cudaStream_t stream,
                                               int scatter_sms)
 {
-  nvshmem_scatter_temp_put_mem_sort_idx_func<InputT, int32_t, EmbeddingT>(
-    wm_comm,
-    input,
-    temp_input,
-    input_desc,
-    indices,
-    indice_count,
-    embeding_nvshmem_ptr,
-    embedding_desc,
-    embedding_entry_count_per_rank,
-    p_env_fns,
-    stream,
-    scatter_sms);
+  nvshmem_scatter_temp_put_mem_sort_idx_func<InputT, int32_t, EmbeddingT>(wm_comm,
+                                                                          input,
+                                                                          temp_input,
+                                                                          input_desc,
+                                                                          indices,
+                                                                          indice_count,
+                                                                          embeding_nvshmem_ptr,
+                                                                          embedding_desc,
+                                                                          embedding_entry_offsets,
+                                                                          p_env_fns,
+                                                                          stream,
+                                                                          scatter_sms);
 }
 
 REGISTER_DISPATCH_TWO_TYPES(NvshmemScatterFuncFloatingInt32,
@@ -65,7 +64,7 @@ wholememory_error_code_t nvshmem_scatter_floating_int32_func(
   wholememory_array_description_t indices_desc,
   wholememory_nvshmem_ref_t embeding_nvshmem_ptr,
   wholememory_matrix_description_t embedding_desc,
-  size_t embedding_entry_count_per_rank,
+  size_t* embedding_entry_offsets,
   wholememory_env_func_t* p_env_fns,
   cudaStream_t stream,
   int scatter_sms)
@@ -86,7 +85,7 @@ wholememory_error_code_t nvshmem_scatter_floating_int32_func(
                        indices_desc.size,
                        embeding_nvshmem_ptr,
                        embedding_desc,
-                       embedding_entry_count_per_rank,
+                       embedding_entry_offsets,
                        p_env_fns,
                        stream,
                        scatter_sms);

--- a/cpp/src/wholememory_ops/functions/nvshmem_scatter_func_impl_floating_data_int64_indices.cu
+++ b/cpp/src/wholememory_ops/functions/nvshmem_scatter_func_impl_floating_data_int64_indices.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,24 +31,23 @@ void nvshmem_scatter_floating_int64_temp_func(wholememory_comm_t wm_comm,
                                               int64_t indice_count,
                                               wholememory_nvshmem_ref_t embeding_nvshmem_ptr,
                                               wholememory_matrix_description_t embedding_desc,
-                                              size_t embedding_entry_count_per_rank,
+                                              size_t* embedding_entry_offsets,
                                               wholememory_env_func_t* p_env_fns,
                                               cudaStream_t stream,
                                               int scatter_sms)
 {
-  nvshmem_scatter_temp_put_mem_sort_idx_func<InputT, int64_t, EmbeddingT>(
-    wm_comm,
-    input,
-    temp_input,
-    input_desc,
-    indices,
-    indice_count,
-    embeding_nvshmem_ptr,
-    embedding_desc,
-    embedding_entry_count_per_rank,
-    p_env_fns,
-    stream,
-    scatter_sms);
+  nvshmem_scatter_temp_put_mem_sort_idx_func<InputT, int64_t, EmbeddingT>(wm_comm,
+                                                                          input,
+                                                                          temp_input,
+                                                                          input_desc,
+                                                                          indices,
+                                                                          indice_count,
+                                                                          embeding_nvshmem_ptr,
+                                                                          embedding_desc,
+                                                                          embedding_entry_offsets,
+                                                                          p_env_fns,
+                                                                          stream,
+                                                                          scatter_sms);
 }
 
 REGISTER_DISPATCH_TWO_TYPES(NvshmemScatterFuncFloatingInt64,
@@ -65,7 +64,7 @@ wholememory_error_code_t nvshmem_scatter_floating_int64_func(
   wholememory_array_description_t indices_desc,
   wholememory_nvshmem_ref_t embeding_nvshmem_ptr,
   wholememory_matrix_description_t embedding_desc,
-  size_t embedding_entry_count_per_rank,
+  size_t* embedding_entry_offsets,
   wholememory_env_func_t* p_env_fns,
   cudaStream_t stream,
   int scatter_sms)
@@ -86,7 +85,7 @@ wholememory_error_code_t nvshmem_scatter_floating_int64_func(
                        indices_desc.size,
                        embeding_nvshmem_ptr,
                        embedding_desc,
-                       embedding_entry_count_per_rank,
+                       embedding_entry_offsets,
                        p_env_fns,
                        stream,
                        scatter_sms);

--- a/cpp/src/wholememory_ops/functions/nvshmem_scatter_func_impl_integer_data_int32_indices.cu
+++ b/cpp/src/wholememory_ops/functions/nvshmem_scatter_func_impl_integer_data_int32_indices.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,24 +31,23 @@ void nvshmem_scatter_integer_int32_temp_func(wholememory_comm_t wm_comm,
                                              int64_t indice_count,
                                              wholememory_nvshmem_ref_t embeding_nvshmem_ptr,
                                              wholememory_matrix_description_t embedding_desc,
-                                             size_t embedding_entry_count_per_rank,
+                                             size_t* embedding_entry_offsets,
                                              wholememory_env_func_t* p_env_fns,
                                              cudaStream_t stream,
                                              int scatter_sms)
 {
-  nvshmem_scatter_temp_put_mem_sort_idx_func<InputT, int32_t, EmbeddingT>(
-    wm_comm,
-    input,
-    temp_input,
-    input_desc,
-    indices,
-    indice_count,
-    embeding_nvshmem_ptr,
-    embedding_desc,
-    embedding_entry_count_per_rank,
-    p_env_fns,
-    stream,
-    scatter_sms);
+  nvshmem_scatter_temp_put_mem_sort_idx_func<InputT, int32_t, EmbeddingT>(wm_comm,
+                                                                          input,
+                                                                          temp_input,
+                                                                          input_desc,
+                                                                          indices,
+                                                                          indice_count,
+                                                                          embeding_nvshmem_ptr,
+                                                                          embedding_desc,
+                                                                          embedding_entry_offsets,
+                                                                          p_env_fns,
+                                                                          stream,
+                                                                          scatter_sms);
 }
 
 REGISTER_DISPATCH_TWO_TYPES(NvshmemScatterFuncIntegerInt32,
@@ -65,7 +64,7 @@ wholememory_error_code_t nvshmem_scatter_integer_int32_func(
   wholememory_array_description_t indices_desc,
   wholememory_nvshmem_ref_t embeding_nvshmem_ptr,
   wholememory_matrix_description_t embedding_desc,
-  size_t embedding_entry_count_per_rank,
+  size_t* embedding_entry_offsets,
   wholememory_env_func_t* p_env_fns,
   cudaStream_t stream,
   int scatter_sms)
@@ -86,7 +85,7 @@ wholememory_error_code_t nvshmem_scatter_integer_int32_func(
                        indices_desc.size,
                        embeding_nvshmem_ptr,
                        embedding_desc,
-                       embedding_entry_count_per_rank,
+                       embedding_entry_offsets,
                        p_env_fns,
                        stream,
                        scatter_sms);

--- a/cpp/src/wholememory_ops/functions/nvshmem_scatter_func_impl_integer_data_int64_indices.cu
+++ b/cpp/src/wholememory_ops/functions/nvshmem_scatter_func_impl_integer_data_int64_indices.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,24 +31,23 @@ void nvshmem_scatter_integer_int64_temp_func(wholememory_comm_t wm_comm,
                                              int64_t indice_count,
                                              wholememory_nvshmem_ref_t embeding_nvshmem_ptr,
                                              wholememory_matrix_description_t embedding_desc,
-                                             size_t embedding_entry_count_per_rank,
+                                             size_t* embedding_entry_offsets,
                                              wholememory_env_func_t* p_env_fns,
                                              cudaStream_t stream,
                                              int scatter_sms)
 {
-  nvshmem_scatter_temp_put_mem_sort_idx_func<InputT, int64_t, EmbeddingT>(
-    wm_comm,
-    input,
-    temp_input,
-    input_desc,
-    indices,
-    indice_count,
-    embeding_nvshmem_ptr,
-    embedding_desc,
-    embedding_entry_count_per_rank,
-    p_env_fns,
-    stream,
-    scatter_sms);
+  nvshmem_scatter_temp_put_mem_sort_idx_func<InputT, int64_t, EmbeddingT>(wm_comm,
+                                                                          input,
+                                                                          temp_input,
+                                                                          input_desc,
+                                                                          indices,
+                                                                          indice_count,
+                                                                          embeding_nvshmem_ptr,
+                                                                          embedding_desc,
+                                                                          embedding_entry_offsets,
+                                                                          p_env_fns,
+                                                                          stream,
+                                                                          scatter_sms);
 }
 
 REGISTER_DISPATCH_TWO_TYPES(NvshmemScatterFuncIntegerInt64,
@@ -65,7 +64,7 @@ wholememory_error_code_t nvshmem_scatter_integer_int64_func(
   wholememory_array_description_t indices_desc,
   wholememory_nvshmem_ref_t embeding_nvshmem_ptr,
   wholememory_matrix_description_t embedding_desc,
-  size_t embedding_entry_count_per_rank,
+  size_t* embedding_entry_offsets,
   wholememory_env_func_t* p_env_fns,
   cudaStream_t stream,
   int scatter_sms)
@@ -86,7 +85,7 @@ wholememory_error_code_t nvshmem_scatter_integer_int64_func(
                        indices_desc.size,
                        embeding_nvshmem_ptr,
                        embedding_desc,
-                       embedding_entry_count_per_rank,
+                       embedding_entry_offsets,
                        p_env_fns,
                        stream,
                        scatter_sms);

--- a/cpp/src/wholememory_ops/gather_op_impl_nccl.cu
+++ b/cpp/src/wholememory_ops/gather_op_impl_nccl.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,21 +49,8 @@ wholememory_error_code_t wholememory_gather_nccl(wholememory_handle_t wholememor
 
     wm_thrust_allocator thrust_allocator(p_env_fns);
 
-    size_t embedding_size_per_rank;
-    WHOLEMEMORY_RETURN_ON_FAIL(
-      wholememory_get_partition_plan(&embedding_size_per_rank, wholememory_handle));
-
     size_t element_size         = wholememory_dtype_get_element_size(wholememory_desc.dtype);
     size_t embedding_entry_size = element_size * wholememory_desc.stride;
-
-    WHOLEMEMORY_EXPECTS_NOTHROW(
-      embedding_size_per_rank % embedding_entry_size == 0,
-      "embedding_size_per_rank=%ld is not multiple of embedding_entry_size=%ldx%ld",
-      embedding_size_per_rank,
-      element_size,
-      wholememory_desc.stride);
-
-    size_t embedding_entry_count_per_rank = embedding_size_per_rank / embedding_entry_size;
 
     wholememory_comm_t wm_comm;
     WHOLEMEMORY_RETURN_ON_FAIL(wholememory_get_communicator(&wm_comm, wholememory_handle));
@@ -83,18 +70,44 @@ wholememory_error_code_t wholememory_gather_nccl(wholememory_handle_t wholememor
       static_cast<int64_t*>(dev_raw_indice.device_malloc(indice_desc.size, WHOLEMEMORY_DT_INT64));
 
     int64_t total_recv_count = 0;
+
+    temp_memory_handle dev_embedding_entry_offsets_handle(p_env_fns);
+    size_t* dev_embedding_entry_offsets_ptr = static_cast<size_t*>(
+      dev_embedding_entry_offsets_handle.device_malloc(world_size + 1, WHOLEMEMORY_DT_INT64));
+    temp_memory_handle host_embedding_entry_offsets_handle(p_env_fns);
+    size_t* host_embedding_entry_offsets_ptr = static_cast<size_t*>(
+      host_embedding_entry_offsets_handle.host_malloc(world_size + 1, WHOLEMEMORY_DT_INT64));
+
+    WHOLEMEMORY_RETURN_ON_FAIL(
+      wholememory_get_rank_partition_offsets(host_embedding_entry_offsets_ptr, wholememory_handle));
+    for (int i = 0; i < world_size + 1; i++) {
+      size_t offset = host_embedding_entry_offsets_ptr[i];
+      WHOLEMEMORY_EXPECTS_NOTHROW(
+        offset % embedding_entry_size == 0,
+        "embedding memory offset of rank%d=%ld is not multiple of embedding_entry_size=%ldx%ld",
+        i,
+        offset,
+        element_size,
+        wholememory_desc.stride);
+      host_embedding_entry_offsets_ptr[i] /= embedding_entry_size;
+    }
+
+    WM_CUDA_CHECK(cudaMemcpyAsync(dev_embedding_entry_offsets_ptr,
+                                  host_embedding_entry_offsets_ptr,
+                                  (world_size + 1) * sizeof(size_t),
+                                  cudaMemcpyHostToDevice,
+                                  stream));
     WHOLEMEMORY_RETURN_ON_FAIL(bucket_and_exchange_ids_func(indices,
                                                             indice_desc,
                                                             host_recv_rank_id_count_ptr,
                                                             host_rank_id_count_ptr,
                                                             &dev_recv_indice_buffer,
                                                             dev_raw_indice_ptr,
-                                                            embedding_entry_count_per_rank,
+                                                            dev_embedding_entry_offsets_ptr,
                                                             wm_comm,
                                                             &thrust_allocator,
                                                             p_env_fns,
                                                             stream));
-
     // Local Gather
     for (int i = 0; i < world_size; i++) {
       total_recv_count += host_recv_rank_id_count_ptr[i];

--- a/cpp/src/wholememory_ops/scatter_op_impl.nvshmem.cu
+++ b/cpp/src/wholememory_ops/scatter_op_impl.nvshmem.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,7 +49,7 @@ wholememory_error_code_t nvshmem_scatter_floating_int32_func(
   wholememory_array_description_t indices_desc,
   wholememory_nvshmem_ref_t embeding_nvshmem_ptr,
   wholememory_matrix_description_t embedding_desc,
-  size_t embedding_entry_count_per_rank,
+  size_t* embedding_entry_offsets,
   wholememory_env_func_t* p_env_fns,
   cudaStream_t stream,
   int scatter_sms);
@@ -63,7 +63,7 @@ wholememory_error_code_t nvshmem_scatter_floating_int64_func(
   wholememory_array_description_t indices_desc,
   wholememory_nvshmem_ref_t embeding_nvshmem_ptr,
   wholememory_matrix_description_t embedding_desc,
-  size_t embedding_entry_count_per_rank,
+  size_t* embedding_entry_offsets,
   wholememory_env_func_t* p_env_fns,
   cudaStream_t stream,
   int scatter_sms);
@@ -77,7 +77,7 @@ wholememory_error_code_t nvshmem_scatter_integer_int32_func(
   wholememory_array_description_t indices_desc,
   wholememory_nvshmem_ref_t embeding_nvshmem_ptr,
   wholememory_matrix_description_t embedding_desc,
-  size_t embedding_entry_count_per_rank,
+  size_t* embedding_entry_offsets,
   wholememory_env_func_t* p_env_fns,
   cudaStream_t stream,
   int scatter_sms);
@@ -91,7 +91,7 @@ wholememory_error_code_t nvshmem_scatter_integer_int64_func(
   wholememory_array_description_t indices_desc,
   wholememory_nvshmem_ref_t embeding_nvshmem_ptr,
   wholememory_matrix_description_t embedding_desc,
-  size_t embedding_entry_count_per_rank,
+  size_t* embedding_entry_offsets,
   wholememory_env_func_t* p_env_fns,
   cudaStream_t stream,
   int scatter_sms);
@@ -122,29 +122,41 @@ wholememory_error_code_t wholememory_scatter_nvshmem(
       return WHOLEMEMORY_INVALID_INPUT;
     }
 
-    size_t embedding_size_per_rank;
-    WHOLEMEMORY_RETURN_ON_FAIL(
-      wholememory_get_partition_plan(&embedding_size_per_rank, wholememory_handle));
-
-    size_t element_size         = wholememory_dtype_get_element_size(wholememory_desc.dtype);
-    size_t embedding_entry_size = element_size * wholememory_desc.stride;
-
-    WHOLEMEMORY_EXPECTS_NOTHROW(
-      embedding_size_per_rank % embedding_entry_size == 0,
-      "embedding_size_per_rank=%ld is not multiple of embedding_entry_size=%ldx%ld",
-      embedding_size_per_rank,
-      element_size,
-      wholememory_desc.stride);
-
-    size_t embedding_entry_count_per_rank = embedding_size_per_rank / embedding_entry_size;
-
     wholememory_comm_t wm_comm;
     WHOLEMEMORY_RETURN_ON_FAIL(wholememory_get_communicator(&wm_comm, wholememory_handle));
 
     int world_size;
     WHOLEMEMORY_RETURN_ON_FAIL(wholememory_communicator_get_size(&world_size, wm_comm));
-    int world_rank;
-    WHOLEMEMORY_RETURN_ON_FAIL(wholememory_communicator_get_rank(&world_rank, wm_comm));
+
+    temp_memory_handle dev_embedding_entry_offsets_handle(p_env_fns);
+    size_t* dev_embedding_entry_offsets_ptr = static_cast<size_t*>(
+      dev_embedding_entry_offsets_handle.device_malloc(world_size + 1, WHOLEMEMORY_DT_INT64));
+    temp_memory_handle host_embedding_entry_offsets_handle(p_env_fns);
+    size_t* host_embedding_entry_offsets_ptr = static_cast<size_t*>(
+      host_embedding_entry_offsets_handle.host_malloc(world_size + 1, WHOLEMEMORY_DT_INT64));
+
+    WHOLEMEMORY_RETURN_ON_FAIL(
+      wholememory_get_rank_partition_offsets(host_embedding_entry_offsets_ptr, wholememory_handle));
+
+    size_t element_size         = wholememory_dtype_get_element_size(wholememory_desc.dtype);
+    size_t embedding_entry_size = element_size * wholememory_desc.stride;
+    for (int i = 0; i < world_size + 1; i++) {
+      size_t offset = host_embedding_entry_offsets_ptr[i];
+      WHOLEMEMORY_EXPECTS_NOTHROW(
+        offset % embedding_entry_size == 0,
+        "embedding memory offset of rank%d=%ld is not multiple of embedding_entry_size=%ldx%ld",
+        i,
+        offset,
+        element_size,
+        wholememory_desc.stride);
+      host_embedding_entry_offsets_ptr[i] /= embedding_entry_size;
+    }
+    WM_CUDA_CHECK(cudaMemcpyAsync(dev_embedding_entry_offsets_ptr,
+                                  host_embedding_entry_offsets_ptr,
+                                  (world_size + 1) * sizeof(size_t),
+                                  cudaMemcpyHostToDevice,
+                                  stream));
+
     wholememory_nvshmem_ref_t embedding_nvshmem_ref;
     WHOLEMEMORY_RETURN_ON_FAIL(
       wholememory_get_nvshmem_reference(&embedding_nvshmem_ref, wholememory_handle));
@@ -168,7 +180,7 @@ wholememory_error_code_t wholememory_scatter_nvshmem(
                                                        wholememory_array_description_t,
                                                        wholememory_nvshmem_ref_t,
                                                        wholememory_matrix_description_t,
-                                                       size_t,
+                                                       size_t*,
                                                        wholememory_env_func_t*,
                                                        cudaStream_t,
                                                        int);
@@ -195,7 +207,7 @@ wholememory_error_code_t wholememory_scatter_nvshmem(
                                       indices_desc,
                                       embedding_nvshmem_ref,
                                       wholememory_desc,
-                                      embedding_entry_count_per_rank,
+                                      dev_embedding_entry_offsets_ptr,
                                       p_env_fns,
                                       stream,
                                       scatter_sms);

--- a/cpp/tests/wholememory_ops/embedding_test_utils.cu
+++ b/cpp/tests/wholememory_ops/embedding_test_utils.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -526,6 +526,23 @@ void host_random_init_float(float* data, int64_t len, float max_value, float min
   for (int64_t i = 0; i < len; i++) {
     data[i] = dis(e);
   }
+}
+
+void host_random_partition(size_t* partition_sizes, size_t total_size, int partition_count)
+{
+  std::default_random_engine random_engine(0);
+  std::uniform_int_distribution<size_t> uniform(90, 100);
+  size_t acc_size   = 0;
+  size_t random_sum = 0;
+  for (int i = 0; i < partition_count; i++) {
+    partition_sizes[i] = (size_t)uniform(random_engine);
+    random_sum += partition_sizes[i];
+  }
+  for (int i = 0; i < partition_count; i++) {
+    partition_sizes[i] = (size_t)((partition_sizes[i] / (double)random_sum) * total_size);
+    acc_size += partition_sizes[i];
+  }
+  partition_sizes[0] += total_size - acc_size;
 }
 
 }  // namespace testing

--- a/cpp/tests/wholememory_ops/embedding_test_utils.hpp
+++ b/cpp/tests/wholememory_ops/embedding_test_utils.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,6 +62,8 @@ void host_check_embedding_same(void* host_embedding,
                                wholememory_matrix_description_t reference_desc);
 
 void host_random_init_float(float* data, int64_t len, float max_value, float min_value);
+
+void host_random_partition(size_t* partition_sizes, size_t total_size, int partition_count);
 
 }  // namespace testing
 }  // namespace wholememory_ops

--- a/python/pylibwholegraph/pylibwholegraph/tests/wholegraph_torch/ops/test_wholegraph_gather_scatter.py
+++ b/python/pylibwholegraph/pylibwholegraph/tests/wholegraph_torch/ops/test_wholegraph_gather_scatter.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2023, NVIDIA CORPORATION.
+# Copyright (c) 2019-2024, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -15,6 +15,7 @@ import pylibwholegraph.binding.wholememory_binding as wmb
 from pylibwholegraph.utils.multiprocess import multiprocess_run
 from pylibwholegraph.torch.initialize import init_torch_env_and_create_wm_comm
 from pylibwholegraph.torch.dlpack_utils import torch_import_from_dlpack
+from pylibwholegraph.test_utils.test_comm import random_partition
 import torch
 import pylibwholegraph.torch.wholememory_ops as wm_ops
 
@@ -45,6 +46,7 @@ def scatter_gather_test_cast(
     embedding_dim,
     indice_count,
     use_python_binding=True,
+    entry_partition=None
 ):
     world_rank = wm_comm.get_rank()
     world_size = wm_comm.get_size()
@@ -53,7 +55,7 @@ def scatter_gather_test_cast(
         % (world_rank, embedding_count, embedding_dim, indice_count, dt, mt, ml)
     )
     wm_embedding = wmb.create_wholememory_matrix(
-        dt, embedding_count, embedding_dim, -1, wm_comm, mt, ml
+        dt, embedding_count, embedding_dim, -1, wm_comm, mt, ml, entry_partition
     )
 
     scatter_indice = torch.arange(
@@ -86,22 +88,15 @@ def scatter_gather_test_cast(
         torch_import_from_dlpack, wmb.WholeMemoryMemoryLocation.MlDevice, world_rank
     )
 
-    local_ref_start = min(
-        wmb.determine_partition_plan(embedding_count, world_size) * world_rank,
-        embedding_count,
-    )
-    local_ref_end = min(
-        wmb.determine_partition_plan(embedding_count, world_size) * (world_rank + 1),
-        embedding_count,
-    )
-    local_ref_count = local_ref_end - local_ref_start
+    local_ref_start = wm_embedding.get_local_entry_start()
+    local_ref_count = wm_embedding.get_local_entry_count()
     assert local_start == local_ref_start
     assert local_tensor_cuda.dim() == 2
     assert local_tensor_cuda.shape[0] == local_ref_count
     assert local_tensor_cuda.shape[1] == embedding_dim
 
     local_tensor = local_tensor_cuda.cpu()
-    local_indices = torch.arange(local_ref_start, local_ref_end, dtype=torch.int64)
+    local_indices = torch.arange(local_ref_start, local_ref_start + local_ref_count, dtype=torch.int64)
     local_tensor_ref = gen_int_embedding(local_indices, embedding_dim, torch.float)
     # print('\nlocal_tensor %s =%s\nlocal_tensor_ref %s =%s' % (
     #    local_tensor.shape, local_tensor, local_tensor_ref.shape, local_tensor_ref))
@@ -142,6 +137,7 @@ def routine_func(world_rank: int, world_size: int):
     embedding_dim = 256
     indice_count = 100001
     dt = wmb.WholeMemoryDataType.DtFloat
+    entry_partition = random_partition(embedding_count, world_size)
 
     print("")
 
@@ -156,7 +152,7 @@ def routine_func(world_rank: int, world_size: int):
         ]:
             if wm_comm.support_type_location(mt, ml):
                 scatter_gather_test_cast(
-                    wm_comm, dt, mt, ml, embedding_count, embedding_dim, indice_count, True
+                    wm_comm, dt, mt, ml, embedding_count, embedding_dim, indice_count, True, entry_partition
                 )
                 # scatter_gather_test_cast(wm_comm, dt, mt, ml, embedding_count, embedding_dim, indice_count, False)
     wmb.finalize()

--- a/python/pylibwholegraph/pylibwholegraph/torch/tensor.py
+++ b/python/pylibwholegraph/pylibwholegraph/torch/tensor.py
@@ -204,6 +204,7 @@ def create_wholememory_tensor(
     sizes: List[int],
     dtype: torch.dtype,
     strides: List[int],
+    tensor_entry_partition: Union[List[int], None] = None
 ):
     """
     Create empty WholeMemory Tensor. Now only support dim = 1 or 2
@@ -213,6 +214,9 @@ def create_wholememory_tensor(
     :param sizes: size of the tensor
     :param dtype: data type of the tensor
     :param strides: strides of the tensor
+    :param tensor_entry_partition: rank partition based on entry; tensor_entry_partition[i] determines the
+    entry count of rank i and shoud be a positive integer; the sum of tensor_entry_partition should equal to
+    total entry count; entries will be equally partitioned if None
     :return: Allocated WholeMemoryTensor
     """
     dim = len(sizes)
@@ -235,7 +239,7 @@ def create_wholememory_tensor(
     wm_location = str_to_wmb_wholememory_location(memory_location)
 
     return WholeMemoryTensor(
-        wmb.create_wholememory_tensor(td, comm.wmb_comm, wm_memory_type, wm_location)
+        wmb.create_wholememory_tensor(td, comm.wmb_comm, wm_memory_type, wm_location, tensor_entry_partition)
     )
 
 
@@ -247,6 +251,7 @@ def create_wholememory_tensor_from_filelist(
     dtype: torch.dtype,
     last_dim_size: int = 0,
     last_dim_strides: int = -1,
+    tensor_entry_partition: Union[List[int], None] = None
 ):
     """
     Create WholeMemory Tensor from list of binary files.
@@ -257,6 +262,9 @@ def create_wholememory_tensor_from_filelist(
     :param dtype: data type of the tensor
     :param last_dim_size: 0 for create 1-D array, positive value for create matrix column size
     :param last_dim_strides: stride of last_dim, -1 for same as size of last dim.
+    :param tensor_entry_partition: rank partition based on entry; tensor_entry_partition[i] determines the
+    entry count of rank i and shoud be a positive integer; the sum of tensor_entry_partition should equal to
+    total entry count; entries will be equally partitioned if None
     :return: WholeMemoryTensor
     """
     if isinstance(filelist, str):
@@ -284,7 +292,7 @@ def create_wholememory_tensor_from_filelist(
         sizes = [total_entry_count, last_dim_size]
         strides = [last_dim_strides, 1]
     wm_tensor = create_wholememory_tensor(
-        comm, memory_type, memory_location, sizes, dtype, strides
+        comm, memory_type, memory_location, sizes, dtype, strides, tensor_entry_partition
     )
     wm_tensor.from_filelist(filelist)
     return wm_tensor


### PR DESCRIPTION
Allow users to specify the entry size on each rank.

        node_feat_wm_embedding = wgth.create_embedding(
            ...
            embedding_entry_partition=[283071, 401722, 356680, 329221, 238065, 238060, 217897, 384313]
        )

1. embedding_entry_partition[i] indicates the number of embedding entries stored on the rank i.
2. If embedding_entry_partition is None, embedding will be partitioned equally.
3. Only chunked device and distributed host/device are supported.