### PR TITLE
clarify which dependencies in dependencies.yaml are conda-only

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -231,7 +231,7 @@ dependencies:
           - pytest-forked
           - pytest-xdist
     specific:
-      - output_types: [conda, requirements]
+      - output_types: [conda]
         matrices:
           - matrix:
               arch: x86_64
@@ -315,7 +315,7 @@ dependencies:
           - sphinxcontrib-websupport
   pytorch_cpu:
     common:
-      - output_types: [conda, requirements]
+      - output_types: [conda]
         packages:
           - pytorch=2.0.0
           - cpuonly


### PR DESCRIPTION
This project has some dependencies in `dependencies.yaml` which are part of groups that have `output_types: requirements`, but which use version specifiers that aren't recognized by `pip`.

For example, the use of a secondary build component matching a build string (a conda-specific pattern):

https://github.com/rapidsai/wholegraph/blob/f85ee4356f2e3d42195a2e0a6c7f195154c47091/dependencies.yaml#L247

And the use of a single `=` pin (not recognized by `pip`)

https://github.com/rapidsai/wholegraph/blob/f85ee4356f2e3d42195a2e0a6c7f195154c47091/dependencies.yaml#L288

I believe these were intended to only affect `conda` outputs from `rapids-dependency-file-generator`. This marks them that way.

## Notes for Reviewers

I discovered this while running the following `cuda11.8-pip` unified devcontainer from https://github.com/rapidsai/devcontainers.

```shell
rapids-make-pip-env --force
```

That resulted in an error like this when `wholegraph` was included.

```text
ERROR: Invalid requirement: 'pytorch-cuda=11.8': Expected end or semicolon (after name and no valid version specifier)
    pytorch-cuda=11.8
                ^ (from line 75 of /tmp/rapids.requirements.txt)
Hint: = is not a valid operator. Did you mean == ?
```