### PR TITLE
Add cuda-nvml-dev to dependencies.yaml.

### DIFF
--- a/conda/environments/all_cuda-125_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-125_arch-x86_64.yaml
@@ -14,6 +14,7 @@ dependencies:
 - cmake>=3.26.4,!=3.30.0
 - cuda-cudart-dev
 - cuda-nvcc
+- cuda-nvml-dev
 - cuda-nvtx
 - cuda-version=12.5
 - cudnn=8.8

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -182,6 +182,7 @@ dependencies:
               cuda: "12.*"
             packages:
               - cuda-cudart-dev
+              - cuda-nvml-dev
               - cuda-nvtx
   checks:
     common:


### PR DESCRIPTION
This adds a missing dependency on `cuda-nvml-dev` in `dependencies.yaml`. See https://github.com/rapidsai/wholegraph/pull/191/files#r1687368784.
