### PR TITLE
Remove NumPy <2 pin

### DIFF
--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -30,7 +30,7 @@ dependencies:
 - nbsphinx
 - nccl
 - ninja
-- numpy>=1.23,<2.0a0
+- numpy>=1.23,<3
 - numpydoc
 - nvcc_linux-64=11.8
 - pre-commit

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -30,7 +30,7 @@ dependencies:
 - nbsphinx
 - nccl
 - ninja
-- numpy>=1.23,<3
+- numpy>=1.23,<3.0a0
 - numpydoc
 - nvcc_linux-64=11.8
 - pre-commit

--- a/conda/environments/all_cuda-125_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-125_arch-x86_64.yaml
@@ -32,7 +32,7 @@ dependencies:
 - nbsphinx
 - nccl
 - ninja
-- numpy>=1.23,<2.0a0
+- numpy>=1.23,<3
 - numpydoc
 - pre-commit
 - pydata-sphinx-theme

--- a/conda/environments/all_cuda-125_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-125_arch-x86_64.yaml
@@ -32,7 +32,7 @@ dependencies:
 - nbsphinx
 - nccl
 - ninja
-- numpy>=1.23,<3
+- numpy>=1.23,<3.0a0
 - numpydoc
 - pre-commit
 - pydata-sphinx-theme

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -227,7 +227,7 @@ dependencies:
       - output_types: [conda, requirements]
         packages:
           - ninja
-          - numpy>=1.23,<2.0a0
+          - numpy>=1.23,<3
           - pytest
           - pytest-forked
           - pytest-xdist

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -227,7 +227,7 @@ dependencies:
       - output_types: [conda, requirements]
         packages:
           - ninja
-          - numpy>=1.23,<3
+          - numpy>=1.23,<3.0a0
           - pytest
           - pytest-forked
           - pytest-xdist


### PR DESCRIPTION
This PR removes the NumPy<2 pin.  `wholegraph` does not appear to be a heavy user of NumPy or CuPy, so it should be fine to simply remove the pin.
For other RAPIDS projects with heavier dependency, CuPy 13.3.0 was required (just released) to have sufficient good CuPy/NumPy interoperability.