### PR TITLE
Ensure pylibwholegraph conda packages have the license

### DIFF
--- a/conda/recipes/pylibwholegraph/meta.yaml
+++ b/conda/recipes/pylibwholegraph/meta.yaml
@@ -75,4 +75,6 @@ requirements:
 
 about:
   home: https://rapids.ai/
+  license: Apache-2.0
+  license_file: ../../../LICENSE
   summary: pylibwholegraph library


### PR DESCRIPTION
Just adds the existing license to the `pylibwholegraph` conda recipe.
