### PR TITLE
bump NCCL floor to 2.18.1.1, relax PyTorch pin

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -12,23 +12,23 @@ concurrency:
 jobs:
   pr-builder:
     needs:
-      # - checks
+      - checks
       - conda-cpp-build
       - conda-cpp-tests
       - conda-python-build
       - conda-python-tests
-      # - docs-build
-      # - wheel-build-pylibwholegraph
-      # - wheel-test-pylibwholegraph
+      - docs-build
+      - wheel-build-pylibwholegraph
+      - wheel-test-pylibwholegraph
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@branch-24.10
-  # checks:
-  #   secrets: inherit
-  #   uses: rapidsai/shared-workflows/.github/workflows/checks.yaml@branch-24.10
-  #   with:
-  #     enable_check_generated_files: false
+  checks:
+    secrets: inherit
+    uses: rapidsai/shared-workflows/.github/workflows/checks.yaml@branch-24.10
+    with:
+      enable_check_generated_files: false
   conda-cpp-build:
-    # needs: checks
+    needs: checks
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-build.yaml@branch-24.10
     with:
@@ -37,7 +37,7 @@ jobs:
   conda-cpp-tests:
     needs: conda-cpp-build
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-tests.yaml@test-cuda-11.4
+    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-tests.yaml@branch-24.10
     with:
       build_type: pull-request
   conda-python-build:
@@ -49,30 +49,30 @@ jobs:
   conda-python-tests:
     needs: conda-python-build
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@test-cuda-11.4
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@branch-24.10
     with:
       build_type: pull-request
-  # docs-build:
-  #   needs: conda-python-build
-  #   secrets: inherit
-  #   uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@branch-24.10
-  #   with:
-  #     build_type: pull-request
-  #     arch: "amd64"
-  #     container_image: "rapidsai/ci-conda:latest"
-  #     run_script: "ci/build_docs.sh"
-  # wheel-build-pylibwholegraph:
-  #   needs: checks
-  #   secrets: inherit
-  #   uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@branch-24.10
-  #   with:
-  #     build_type: pull-request
-  #     script: ci/build_wheel.sh
-  # wheel-test-pylibwholegraph:
-  #   needs: wheel-build-pylibwholegraph
-  #   secrets: inherit
-  #   uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@branch-24.10
-  #   with:
-  #     build_type: pull-request
-  #     script: ci/test_wheel.sh
-  #     matrix_filter: map(select(.ARCH == "amd64"))
+  docs-build:
+    needs: conda-python-build
+    secrets: inherit
+    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@branch-24.10
+    with:
+      build_type: pull-request
+      arch: "amd64"
+      container_image: "rapidsai/ci-conda:latest"
+      run_script: "ci/build_docs.sh"
+  wheel-build-pylibwholegraph:
+    needs: checks
+    secrets: inherit
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@branch-24.10
+    with:
+      build_type: pull-request
+      script: ci/build_wheel.sh
+  wheel-test-pylibwholegraph:
+    needs: wheel-build-pylibwholegraph
+    secrets: inherit
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@branch-24.10
+    with:
+      build_type: pull-request
+      script: ci/test_wheel.sh
+      matrix_filter: map(select(.ARCH == "amd64"))

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -22,11 +22,11 @@ jobs:
       # - wheel-test-pylibwholegraph
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@branch-24.10
-  checks:
-    secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/checks.yaml@branch-24.10
-    with:
-      enable_check_generated_files: false
+  # checks:
+  #   secrets: inherit
+  #   uses: rapidsai/shared-workflows/.github/workflows/checks.yaml@branch-24.10
+  #   with:
+  #     enable_check_generated_files: false
   conda-cpp-build:
     # needs: checks
     secrets: inherit

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -12,14 +12,14 @@ concurrency:
 jobs:
   pr-builder:
     needs:
-      - checks
+      # - checks
       - conda-cpp-build
       - conda-cpp-tests
       - conda-python-build
       - conda-python-tests
-      - docs-build
-      - wheel-build-pylibwholegraph
-      - wheel-test-pylibwholegraph
+      # - docs-build
+      # - wheel-build-pylibwholegraph
+      # - wheel-test-pylibwholegraph
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@branch-24.10
   checks:
@@ -28,7 +28,7 @@ jobs:
     with:
       enable_check_generated_files: false
   conda-cpp-build:
-    needs: checks
+    # needs: checks
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-build.yaml@branch-24.10
     with:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -37,7 +37,7 @@ jobs:
   conda-cpp-tests:
     needs: conda-cpp-build
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-tests.yaml@branch-24.10
+    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-tests.yaml@test-cuda-11.4
     with:
       build_type: pull-request
   conda-python-build:
@@ -49,30 +49,30 @@ jobs:
   conda-python-tests:
     needs: conda-python-build
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@branch-24.10
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@test-cuda-11.4
     with:
       build_type: pull-request
-  docs-build:
-    needs: conda-python-build
-    secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@branch-24.10
-    with:
-      build_type: pull-request
-      arch: "amd64"
-      container_image: "rapidsai/ci-conda:latest"
-      run_script: "ci/build_docs.sh"
-  wheel-build-pylibwholegraph:
-    needs: checks
-    secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@branch-24.10
-    with:
-      build_type: pull-request
-      script: ci/build_wheel.sh
-  wheel-test-pylibwholegraph:
-    needs: wheel-build-pylibwholegraph
-    secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@branch-24.10
-    with:
-      build_type: pull-request
-      script: ci/test_wheel.sh
-      matrix_filter: map(select(.ARCH == "amd64"))
+  # docs-build:
+  #   needs: conda-python-build
+  #   secrets: inherit
+  #   uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@branch-24.10
+  #   with:
+  #     build_type: pull-request
+  #     arch: "amd64"
+  #     container_image: "rapidsai/ci-conda:latest"
+  #     run_script: "ci/build_docs.sh"
+  # wheel-build-pylibwholegraph:
+  #   needs: checks
+  #   secrets: inherit
+  #   uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@branch-24.10
+  #   with:
+  #     build_type: pull-request
+  #     script: ci/build_wheel.sh
+  # wheel-test-pylibwholegraph:
+  #   needs: wheel-build-pylibwholegraph
+  #   secrets: inherit
+  #   uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@branch-24.10
+  #   with:
+  #     build_type: pull-request
+  #     script: ci/test_wheel.sh
+  #     matrix_filter: map(select(.ARCH == "amd64"))

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -28,7 +28,7 @@ dependencies:
 - librmm==24.10.*,>=0.0.0a0
 - nanobind>=0.2.0
 - nbsphinx
-- nccl
+- nccl>=2.18.1.1
 - ninja
 - numpy>=1.23,<3.0a0
 - numpydoc

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -40,7 +40,7 @@ dependencies:
 - pytest-xdist
 - python>=3.10,<3.13
 - pytorch-cuda=11.8
-- pytorch=2.0.0
+- pytorch>=2.0,<2.4.0a0
 - rapids-build-backend>=0.3.0,<0.4.0.dev0
 - recommonmark
 - scikit-build-core>=0.10.0

--- a/conda/environments/all_cuda-125_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-125_arch-x86_64.yaml
@@ -30,7 +30,7 @@ dependencies:
 - librmm==24.10.*,>=0.0.0a0
 - nanobind>=0.2.0
 - nbsphinx
-- nccl
+- nccl>=2.18.1.1
 - ninja
 - numpy>=1.23,<3.0a0
 - numpydoc

--- a/conda/recipes/libwholegraph/conda_build_config.yaml
+++ b/conda/recipes/libwholegraph/conda_build_config.yaml
@@ -17,7 +17,7 @@ doxygen_version:
   - ">=1.8.11"
 
 nccl_version:
-  - ">=2.9.9"
+  - ">=2.18.1.1"
 
 c_stdlib:
   - sysroot

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -87,7 +87,7 @@ dependencies:
           - libraft-headers==24.10.*,>=0.0.0a0
           - librmm==24.10.*,>=0.0.0a0
           - nanobind>=0.2.0
-          - nccl
+          - &nccl nccl>=2.18.1.1
     specific:
       - output_types: conda
         matrices:
@@ -216,14 +216,14 @@ dependencies:
     common:
       - output_types: [conda]
         packages:
-          - nccl
+          - *nccl
   test_python:
     common:
       - output_types: [conda]
         packages:
           - c-compiler
           - cxx-compiler
-          - nccl
+          - *nccl
       - output_types: [conda, requirements]
         packages:
           - ninja

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -285,13 +285,13 @@ dependencies:
               # If conda-forge supports the new cuda-* packages for CUDA 11.8
               # at some point, then we can fully support/properly specify
               # this environment.
-              - pytorch=2.0.0
+              - &pytorch pytorch>=2.0,<2.4.0a0
               - pytorch-cuda=11.8
           - matrix:
               arch: aarch64
               cuda: "11.8"
             packages:
-              - pytorch=2.0.0
+              - *pytorch
               - pytorch-cuda=11.8
           - matrix:
             packages:
@@ -318,7 +318,7 @@ dependencies:
     common:
       - output_types: [conda]
         packages:
-          - pytorch=2.0.0
+          - *pytorch
           - cpuonly
   clang_tools:
     common:


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/102

Fixes #217

## Notes for Reviewers

### How I tested this

Temporarily added a CUDA 11.4.3 test job to CI here (the same specs as the failing nightly), by pointing at the branch from https://github.com/rapidsai/shared-workflows/pull/246.

Observed the exact same failures with CUDA 11.4 reported in https://github.com/rapidsai/build-planning/issues/102.

```text
...
  + nccl                     2.10.3.1  hcad2f07_0                  rapidsai-nightly     125MB
...
./WHOLEGRAPH_CSR_WEIGHTED_SAMPLE_WITHOUT_REPLACEMENT_TEST: symbol lookup error: /opt/conda/envs/test/bin/gtests/libwholegraph/../../../lib/libwholegraph.so: undefined symbol: ncclCommSplit
sh -c exec "$0" ./WHOLEMEMORY_HANDLE_TEST 
./WHOLEMEMORY_HANDLE_TEST: symbol lookup error: /opt/conda/envs/test/bin/gtests/libwholegraph/../../../lib/libwholegraph.so: undefined symbol: ncclCommSplit
sh -c exec "$0" ./GRAPH_APPEND_UNIQUE_TEST 
```

([build link](https://github.com/rapidsai/wholegraph/actions/runs/10966022370/job/30453393224?pr=218))

Pushed a commit adding a floor of `nccl>=2.18.1.1`. Saw all tests pass with CUDA 11.4 😁 

```text
...
  + nccl                     2.22.3.1  hee583db_1                  conda-forge          131MB
...
(various log messages showing all tests passed)
```

([build link](https://github.com/rapidsai/wholegraph/actions/runs/10966210441/job/30454147250?pr=218))