### PR TITLE
bump NCCL floor to 2.19

### DIFF
--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -28,7 +28,7 @@ dependencies:
 - librmm==24.10.*,>=0.0.0a0
 - nanobind>=0.2.0
 - nbsphinx
-- nccl>=2.18.1.1
+- nccl>=2.19
 - ninja
 - numpy>=1.23,<3.0a0
 - numpydoc

--- a/conda/environments/all_cuda-125_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-125_arch-x86_64.yaml
@@ -30,7 +30,7 @@ dependencies:
 - librmm==24.10.*,>=0.0.0a0
 - nanobind>=0.2.0
 - nbsphinx
-- nccl>=2.18.1.1
+- nccl>=2.19
 - ninja
 - numpy>=1.23,<3.0a0
 - numpydoc

--- a/conda/recipes/libwholegraph/conda_build_config.yaml
+++ b/conda/recipes/libwholegraph/conda_build_config.yaml
@@ -17,7 +17,7 @@ doxygen_version:
   - ">=1.8.11"
 
 nccl_version:
-  - ">=2.18.1.1"
+  - ">=2.19"
 
 c_stdlib:
   - sysroot

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -87,7 +87,7 @@ dependencies:
           - libraft-headers==24.10.*,>=0.0.0a0
           - librmm==24.10.*,>=0.0.0a0
           - nanobind>=0.2.0
-          - &nccl nccl>=2.18.1.1
+          - &nccl nccl>=2.19
     specific:
       - output_types: conda
         matrices:


### PR DESCRIPTION
Follow-up to #218 

This bumps the NCCL floor here slightly higher, to `>=2.19`. Part of a RAPIDS-wide update of that floor for the 24.10 release. See https://github.com/rapidsai/build-planning/issues/102#issuecomment-2375595743 for context.

cc @linhu-nv for awareness