### PR TITLE
Add a new memory type: Hierarchy

### DIFF
--- a/cpp/include/wholememory/wholememory.h
+++ b/cpp/include/wholememory/wholememory.h
@@ -284,6 +284,25 @@ wholememory_error_code_t wholememory_get_communicator(wholememory_comm_t* comm,
                                                       wholememory_handle_t wholememory_handle);
 
 /**
+ * Get underlying Wholememory Local Communicator for "Hierarchy" memory type from WholeMemory Handle
+ * @param comm : returned Local WholeMemory Communicator
+ * @param wholememory_handle : WholeMemory Handle
+ * @return : wholememory_error_code_t
+ */
+wholememory_error_code_t wholememory_get_local_communicator(
+  wholememory_comm_t* comm, wholememory_handle_t wholememory_handle);
+
+/**
+ * Get underlying Wholememory Cross Communicator for "Hierarchy" memory type from WholeMemory Handle
+ * One comminicator includes all rank with a same local id from different nodes
+ * @param comm : returned Local WholeMemory Communicator
+ * @param wholememory_handle : WholeMemory Handle
+ * @return : wholememory_error_code_t
+ */
+wholememory_error_code_t wholememory_get_cross_communicator(
+  wholememory_comm_t* comm, wholememory_handle_t wholememory_handle);
+
+/**
  * Get WholeMemory Type
  * @param wholememory_handle : WholeMemory Handle
  * @return : WholeMemory Type

--- a/cpp/include/wholememory/wholememory.h
+++ b/cpp/include/wholememory/wholememory.h
@@ -63,6 +63,7 @@ enum wholememory_memory_type_t {
   WHOLEMEMORY_MT_CONTINUOUS,  /*!< Memory from all ranks are mapped in continuous address space */
   WHOLEMEMORY_MT_CHUNKED,     /*!< Memory from all ranks are mapped in chunked address space */
   WHOLEMEMORY_MT_DISTRIBUTED, /*!< Memory from other ranks are not mapped. */
+  WHOLEMEMORY_MT_HIERARCHY,   /*!< Memory from other ranks are mapped in hierarchy address space */
 };
 
 /**
@@ -206,6 +207,23 @@ wholememory_error_code_t wholememory_communicator_get_rank(int* rank, wholememor
  */
 wholememory_error_code_t wholememory_communicator_get_size(int* size, wholememory_comm_t comm);
 
+/**
+ * Get the local rank size of current process in the WholeMemory Communicator
+ * @param local_size : returned local rank size
+ * @param comm : WholeMemory Communicator
+ * @return : wholememory_error_code_t
+ */
+
+wholememory_error_code_t wholememory_communicator_get_local_size(int* local_size,
+                                                                 wholememory_comm_t comm);
+
+/**
+ * Get the clique info of WholeMemory Communicator
+ * @param clique_info : returned clique info
+ * @param comm : WholeMemory Communicator
+ * @return : wholememory_error_code_t
+ */
+
 wholememory_error_code_t wholememory_communicator_get_clique_info(clique_info_t* clique_info,
                                                                   wholememory_comm_t comm);
 
@@ -310,6 +328,20 @@ wholememory_error_code_t wholememory_get_local_memory(void** local_ptr,
                                                       size_t* local_size,
                                                       size_t* local_offset,
                                                       wholememory_handle_t wholememory_handle);
+
+/**
+ * Get local node memory from WholeMemory Handle, all gpus of the rank has direct access to the
+ * memory. Note that this is only available for WHOLEMEMORY_MT_HIERARCHY memory type.
+ * @param local_ptr : returned local node memory pointer
+ * @param local_size : returned local node memory size
+ * @param local_offset : returned local node memory offset from WholeMemory
+ * @param wholememory_handle : WholeMemory Handle
+ * @return : wholememory_error_code_t
+ */
+wholememory_error_code_t wholememory_get_local_node_memory(void** local_ptr,
+                                                           size_t* local_size,
+                                                           size_t* local_offset,
+                                                           wholememory_handle_t wholememory_handle);
 
 /**
  * Get local memory size from WholeMemory Handle of current rank

--- a/cpp/include/wholememory/wholememory.h
+++ b/cpp/include/wholememory/wholememory.h
@@ -295,7 +295,7 @@ wholememory_error_code_t wholememory_get_local_communicator(
 /**
  * Get underlying Wholememory Cross Communicator for "Hierarchy" memory type from WholeMemory Handle
  * One comminicator includes all rank with a same local id from different nodes
- * @param comm : returned Local WholeMemory Communicator
+ * @param comm : returned Cross WholeMemory Communicator
  * @param wholememory_handle : WholeMemory Handle
  * @return : wholememory_error_code_t
  */
@@ -347,20 +347,6 @@ wholememory_error_code_t wholememory_get_local_memory(void** local_ptr,
                                                       size_t* local_size,
                                                       size_t* local_offset,
                                                       wholememory_handle_t wholememory_handle);
-
-/**
- * Get local node memory from WholeMemory Handle, all gpus of the rank has direct access to the
- * memory. Note that this is only available for WHOLEMEMORY_MT_HIERARCHY memory type.
- * @param local_ptr : returned local node memory pointer
- * @param local_size : returned local node memory size
- * @param local_offset : returned local node memory offset from WholeMemory
- * @param wholememory_handle : WholeMemory Handle
- * @return : wholememory_error_code_t
- */
-wholememory_error_code_t wholememory_get_local_node_memory(void** local_ptr,
-                                                           size_t* local_size,
-                                                           size_t* local_offset,
-                                                           wholememory_handle_t wholememory_handle);
 
 /**
  * Get local memory size from WholeMemory Handle of current rank

--- a/cpp/src/wholememory/communicator.cpp
+++ b/cpp/src/wholememory/communicator.cpp
@@ -897,6 +897,13 @@ wholememory_error_code_t communicator_get_size(int* size, wholememory_comm_t com
   return WHOLEMEMORY_SUCCESS;
 }
 
+wholememory_error_code_t communicator_get_local_size(int* local_size,
+                                                     wholememory_comm_t comm) noexcept
+{
+  *local_size = comm->intra_node_rank_num;
+  return WHOLEMEMORY_SUCCESS;
+}
+
 // wholememory_error_code_t communicator_get_clique_rank(int* clique_rank,
 //                                                       wholememory_comm_t comm) noexcept
 // {

--- a/cpp/src/wholememory/communicator.hpp
+++ b/cpp/src/wholememory/communicator.hpp
@@ -291,6 +291,9 @@ wholememory_error_code_t communicator_get_rank(int* rank, wholememory_comm_t com
 
 wholememory_error_code_t communicator_get_size(int* size, wholememory_comm_t comm) noexcept;
 
+wholememory_error_code_t communicator_get_local_size(int* local_size,
+                                                     wholememory_comm_t comm) noexcept;
+
 wholememory_error_code_t communicator_get_clique_info(clique_info_t* clique_info,
                                                       wholememory_comm_t comm) noexcept;
 

--- a/cpp/src/wholememory/embedding.cpp
+++ b/cpp/src/wholememory/embedding.cpp
@@ -964,6 +964,9 @@ wholememory_error_code_t wholememory_create_embedding(
   int embedding_world_size                        = 1;
   WHOLEMEMORY_RETURN_ON_FAIL(wholememory_communicator_get_size(&embedding_world_size, comm));
   if (cache_policy != nullptr) {
+    if (memory_type == WHOLEMEMORY_MT_HIERARCHY) {
+      WHOLEMEMORY_ERROR("Cache is not supported now in hierarchy memory type.");
+    }
     if (cache_policy->cache_comm == comm) {
       if (cache_policy->cache_memory_location != WHOLEMEMORY_ML_DEVICE) {
         WHOLEMEMORY_ERROR(

--- a/cpp/src/wholememory/memory_handle.cpp
+++ b/cpp/src/wholememory/memory_handle.cpp
@@ -1778,7 +1778,7 @@ class hierarchy_wholememory_impl : public wholememory_impl {
 #endif
     } else {
       int world_rank = -1, local_size = -1;
-      wholememory_communicator_get_size(&world_rank, global_comm);
+      wholememory_communicator_get_rank(&world_rank, global_comm);
       wholememory_communicator_get_local_size(&local_size, global_comm);
       wholememory_split_communicator(
         &cross_comm_, global_comm, world_rank % local_size, world_rank / local_size);
@@ -2038,7 +2038,7 @@ wholememory_error_code_t create_wholememory(wholememory_handle_t* wholememory_ha
 #endif
       } else {
         int world_rank = -1, local_size = -1;
-        wholememory_communicator_get_size(&world_rank, comm);
+        wholememory_communicator_get_rank(&world_rank, comm);
         wholememory_communicator_get_local_size(&local_size, comm);
         wholememory_split_communicator(
           &local_comm, comm, world_rank / local_size, world_rank % local_size);

--- a/cpp/src/wholememory/memory_handle.cpp
+++ b/cpp/src/wholememory/memory_handle.cpp
@@ -106,7 +106,7 @@ class wholememory_impl {
     return gref;
   }
   virtual bool contains_pointer(const void* ptr) const = 0;
-  void get_local_memory(void** local_ptr, size_t* local_size, size_t* local_offset) const
+  virtual void get_local_memory(void** local_ptr, size_t* local_size, size_t* local_offset) const
   {
     if (local_ptr != nullptr) *local_ptr = local_partition_memory_pointer_;
     if (local_size != nullptr) *local_size = get_local_size();
@@ -128,7 +128,7 @@ class wholememory_impl {
     *rank_memory_offset = 0;
     return false;
   }
-  [[nodiscard]] size_t get_partition_stride() const
+  [[nodiscard]] virtual size_t get_partition_stride() const
   {
     return rank_partition_strategy_.partition_mem_stride;
   }
@@ -647,6 +647,11 @@ class continuous_device_wholememory_impl : public wholememory_impl {
                        data_granularity,
                        rank_entry_partition)
   {
+    printf(
+      "while in continuous device wholememory creation, the memory_type (%d) and memory_location "
+      "(%d).\n",
+      (int)memory_type,
+      (int)memory_location);
     WHOLEMEMORY_CHECK(type_ == WHOLEMEMORY_MT_CONTINUOUS);
   }
   void create_memory() override
@@ -1747,6 +1752,138 @@ struct wholememory_create_param {
   size_t min_granularity;
 };
 
+class hierarchy_wholememory_impl : public wholememory_impl {
+ public:
+  hierarchy_wholememory_impl(wholememory_handle_t wholememory_handle,
+                             size_t total_size,
+                             wholememory_comm_t global_comm,
+                             wholememory_comm_t local_comm,
+                             wholememory_memory_type_t memory_type,
+                             wholememory_memory_location_t memory_location,
+                             size_t data_granularity)
+    : wholememory_impl(
+        wholememory_handle, total_size, global_comm, memory_type, memory_location, data_granularity)
+  {
+    WHOLEMEMORY_CHECK(memory_type == WHOLEMEMORY_MT_HIERARCHY);
+    local_comm_ = local_comm;
+  }
+  void create_memory() override
+  {
+    std::unique_lock<std::mutex> mlock(local_comm_->mu);
+    local_memory_handle_            = new wholememory_handle_();
+    local_memory_handle_->handle_id = negotiate_handle_id_with_comm_locked(local_comm_);
+    determine_node_size();
+
+    WM_COMM_CHECK_ALL_SAME(local_comm_, WM_MEM_OP_CREATE);
+    wholememory_create_param wcp(node_partition_strategy_.local_mem_size,
+                                 WHOLEMEMORY_MT_CONTINUOUS,
+                                 location_,
+                                 data_granularity_);
+    WM_COMM_CHECK_ALL_SAME(local_comm_, wcp);
+
+    // TODO chunkded memory type and nvshmem type are both not supported yet.
+    if (is_intranode_communicator(local_comm_) || !SupportEGM())
+      if (location_ == WHOLEMEMORY_ML_HOST) {
+        local_memory_handle_->impl =
+          new global_mapped_host_wholememory_impl(local_memory_handle_,
+                                                  node_partition_strategy_.local_mem_size,
+                                                  local_comm_,
+                                                  WHOLEMEMORY_MT_CONTINUOUS,
+                                                  location_,
+                                                  data_granularity_);
+      } else if (location_ == WHOLEMEMORY_ML_DEVICE) {
+        local_memory_handle_->impl =
+          new continuous_device_wholememory_impl(local_memory_handle_,
+                                                 node_partition_strategy_.local_mem_size,
+                                                 local_comm_,
+                                                 WHOLEMEMORY_MT_CONTINUOUS,
+                                                 location_,
+                                                 data_granularity_);
+      } else {
+        WHOLEMEMORY_ERROR("unsupported memory location");
+      }
+    else {
+#if CUDA_VERSION >= 12030
+      local_memory_handle_->impl =
+        new continuous_mnnvl_wholememory_impl(local_memory_handle_,
+                                              node_partition_strategy_.local_mem_size,
+                                              local_comm_,
+                                              WHOLEMEMORY_MT_CONTINUOUS,
+                                              location_,
+                                              data_granularity_);
+#else
+      WHOLEMEMORY_FAIL_NOTHROW("Multinode CONTINOUS is only supported on CUDA version >= 12.3");
+#endif
+    }
+    local_memory_handle_->impl->create_memory();
+    local_comm_->wholememory_map.insert(
+      std::pair<int, wholememory_handle_t>(local_memory_handle_->handle_id, local_memory_handle_));
+    local_node_memory_pointer_ = local_memory_handle_->impl->get_continuous_mapping_pointer();
+  }
+  [[nodiscard]] wholememory_gref_t get_global_reference() const noexcept override
+  {
+    wholememory_gref_t gref{};
+    gref.pointer = local_node_memory_pointer_;
+    gref.stride  = 0;
+    return gref;
+  }
+  void get_local_memory(void** local_ptr, size_t* local_size, size_t* local_offset) const override
+  {
+    get_local_memory_from_handle(local_ptr, local_size, local_offset, local_memory_handle_);
+    *local_offset += node_partition_strategy_.local_mem_offset;
+    return;
+  }
+  void get_local_node_memory(void** local_node_ptr,
+                             size_t* local_node_size,
+                             size_t* local_node_offset)
+  {
+    *local_node_ptr    = local_node_memory_pointer_;
+    *local_node_size   = node_partition_strategy_.local_mem_size;
+    *local_node_offset = node_partition_strategy_.local_mem_offset;
+  }
+  [[nodiscard]] size_t get_partition_stride() const override
+  {
+    return local_memory_handle_->impl->get_partition_stride();
+  }
+  [[nodiscard]] wholememory_comm_t get_local_comm() const { return local_comm_; }
+  void destroy_memory() noexcept override { destroy_wholememory(local_memory_handle_); }
+  bool contains_pointer(const void* ptr) const override
+  {
+    uint64_t int_ptr       = reinterpret_cast<uint64_t>(ptr);
+    uint64_t int_start_ptr = reinterpret_cast<uint64_t>(local_node_memory_pointer_);
+    return int_ptr >= int_start_ptr &&
+           int_ptr < int_start_ptr + node_partition_strategy_.local_mem_size;
+  }
+
+ protected:
+  void determine_node_size()
+  {
+    size_t node_num           = comm_->world_size / local_comm_->world_size;
+    size_t node_id            = comm_->world_rank / local_comm_->world_size;
+    size_t data_slot_count    = total_size_ / data_granularity_;
+    size_t data_slot_per_rank = determine_entry_partition_plan(data_slot_count, comm_->world_size);
+    size_t data_slot_per_node = data_slot_per_rank * local_comm_->world_size;
+    size_t node_data_slot_start = std::min(node_id * data_slot_per_node, data_slot_count);
+    size_t node_data_slot_end   = std::min((node_id + 1) * data_slot_per_node, data_slot_count);
+    size_t node_data_slot_count = node_data_slot_end - node_data_slot_start;
+
+    node_partition_strategy_.local_mem_size       = node_data_slot_count * data_granularity_;
+    node_partition_strategy_.local_mem_offset     = node_data_slot_start * data_granularity_;
+    node_partition_strategy_.partition_mem_stride = data_slot_per_node * data_granularity_;
+  }
+
+  wholememory_handle_t local_memory_handle_;
+  wholememory_comm_t local_comm_;
+  void* local_node_memory_pointer_;
+  struct partition_strategy {
+    // size of memory this rank is responsible for
+    size_t local_mem_size = 0;
+    // start location of the memory this rank is responsible for
+    size_t local_mem_offset     = 0;
+    size_t partition_mem_stride = 0;
+  } node_partition_strategy_;
+};
+
 wholememory_error_code_t create_wholememory(wholememory_handle_t* wholememory_handle_ptr,
                                             size_t total_size,
                                             wholememory_comm_t comm,
@@ -1802,7 +1939,15 @@ wholememory_error_code_t create_wholememory(wholememory_handle_t* wholememory_ha
                                                                      data_granularity,
                                                                      rank_entry_partition);
       }
-    } else if (memory_type == WHOLEMEMORY_MT_CONTINUOUS) {
+    } else if (memory_type == WHOLEMEMORY_MT_CONTINUOUS ||
+               (memory_type == WHOLEMEMORY_MT_HIERARCHY && is_intranode_communicator(comm)) ||
+               (memory_type == WHOLEMEMORY_MT_HIERARCHY && is_intra_mnnvl_communicator(comm))) {
+      if (memory_type == WHOLEMEMORY_MT_HIERARCHY) {
+        WHOLEMEMORY_WARN(
+          "intra-node or intra-mnnvl HIERARCHY memory type is implemented as CONTINUOUS memory "
+          "type");
+        memory_type = WHOLEMEMORY_MT_CONTINUOUS;
+      }
       if (is_intranode_communicator(comm) || !SupportEGM()) {
         if (memory_location == WHOLEMEMORY_ML_HOST) {
           whole_memory_handle->impl = new global_mapped_host_wholememory_impl(whole_memory_handle,
@@ -1852,6 +1997,39 @@ wholememory_error_code_t create_wholememory(wholememory_handle_t* wholememory_ha
                                                                         memory_location,
                                                                         data_granularity,
                                                                         rank_entry_partition);
+      }
+    } else if (memory_type == WHOLEMEMORY_MT_HIERARCHY) {
+      wholememory_comm_t local_comm;
+      if (SupportEGM() && is_intra_mnnvl_communicator(comm)) {
+#if CUDA_VERSION >= 12030
+        clique_info_t* clique_info = nullptr;
+        wholememory_communicator_get_clique_info(clique_info, comm);
+        WHOLEMEMORY_CHECK_NOTHROW(clique_info->is_in_clique);
+        wholememory_split_communicator(
+          &local_comm, comm, clique_info->clique_id, clique_info->clique_rank);
+        whole_memory_handle->impl = new hierarchy_wholememory_impl(whole_memory_handle,
+                                                                   total_size,
+                                                                   comm,
+                                                                   local_comm,
+                                                                   memory_type,
+                                                                   memory_location,
+                                                                   data_granularity);
+#else
+        WHOLEMEMORY_FAIL_NOTHROW("Multinode CONTINUOUS is only supported on CUDA Version >= 12.3");
+#endif
+      } else {
+        int world_rank = -1, local_size = -1;
+        wholememory_communicator_get_size(&world_rank, comm);
+        wholememory_communicator_get_local_size(&local_size, comm);
+        wholememory_split_communicator(
+          &local_comm, comm, world_rank / local_size, world_rank % local_size);
+        whole_memory_handle->impl = new hierarchy_wholememory_impl(whole_memory_handle,
+                                                                   total_size,
+                                                                   comm,
+                                                                   local_comm,
+                                                                   memory_type,
+                                                                   memory_location,
+                                                                   data_granularity);
       }
     } else {
       WHOLEMEMORY_FATAL("Unsupported memory_type (%d) and memory_location (%d).",
@@ -1964,6 +2142,25 @@ wholememory_error_code_t get_local_memory_from_handle(
     return WHOLEMEMORY_INVALID_INPUT;
   }
   wholememory_handle->impl->get_local_memory(local_ptr, local_size, local_offset);
+  return WHOLEMEMORY_SUCCESS;
+}
+
+wholememory_error_code_t get_local_node_memory_from_handle(
+  void** local_ptr,
+  size_t* local_size,
+  size_t* local_offset,
+  wholememory_handle_t wholememory_handle) noexcept
+{
+  if (get_memory_type(wholememory_handle) != WHOLEMEMORY_MT_HIERARCHY) {
+    WHOLEMEMORY_ERROR("Only Hierarchy memory type support get_local_node_memory function.");
+    return WHOLEMEMORY_INVALID_INPUT;
+  }
+  if (wholememory_handle == nullptr || wholememory_handle->impl == nullptr) {
+    return WHOLEMEMORY_INVALID_INPUT;
+  }
+  hierarchy_wholememory_impl* hierarchy_impl =
+    dynamic_cast<hierarchy_wholememory_impl*>(wholememory_handle->impl);
+  hierarchy_impl->get_local_node_memory(local_ptr, local_size, local_offset);
   return WHOLEMEMORY_SUCCESS;
 }
 

--- a/cpp/src/wholememory/memory_handle.hpp
+++ b/cpp/src/wholememory/memory_handle.hpp
@@ -65,6 +65,12 @@ wholememory_error_code_t get_local_memory_from_handle(
   size_t* local_offset,
   wholememory_handle_t wholememory_handle) noexcept;
 
+wholememory_error_code_t get_local_node_memory_from_handle(
+  void** local_ptr,
+  size_t* local_size,
+  size_t* local_offset,
+  wholememory_handle_t wholememory_handle) noexcept;
+
 wholememory_error_code_t get_rank_memory_from_handle(
   void** rank_memory_ptr,
   size_t* rank_memory_size,

--- a/cpp/src/wholememory/memory_handle.hpp
+++ b/cpp/src/wholememory/memory_handle.hpp
@@ -51,6 +51,12 @@ wholememory_error_code_t destroy_wholememory(wholememory_handle_t wholememory_ha
 wholememory_error_code_t get_communicator_from_handle(
   wholememory_comm_t* comm, wholememory_handle_t wholememory_handle) noexcept;
 
+wholememory_error_code_t get_local_communicator_from_handle(
+  wholememory_comm_t* comm, wholememory_handle_t wholememory_handle) noexcept;
+
+wholememory_error_code_t get_cross_communicator_from_handle(
+  wholememory_comm_t* comm, wholememory_handle_t wholememory_handle) noexcept;
+
 wholememory_memory_type_t get_memory_type(wholememory_handle_t wholememory_handle) noexcept;
 
 wholememory_memory_location_t get_memory_location(wholememory_handle_t wholememory_handle) noexcept;

--- a/cpp/src/wholememory/wholememory.cpp
+++ b/cpp/src/wholememory/wholememory.cpp
@@ -75,6 +75,13 @@ wholememory_error_code_t wholememory_communicator_get_size(int* size, wholememor
 {
   return wholememory::communicator_get_size(size, comm);
 }
+
+wholememory_error_code_t wholememory_communicator_get_local_size(int* local_size,
+                                                                 wholememory_comm_t comm)
+{
+  return wholememory::communicator_get_local_size(local_size, comm);
+}
+
 bool wholememory_communicator_is_bind_to_nvshmem(wholememory_comm_t comm)
 {
 #ifdef WITH_NVSHMEM_SUPPORT
@@ -163,6 +170,15 @@ wholememory_error_code_t wholememory_get_local_memory(void** local_ptr,
                                                       wholememory_handle_t wholememory_handle)
 {
   return wholememory::get_local_memory_from_handle(
+    local_ptr, local_size, local_offset, wholememory_handle);
+}
+
+wholememory_error_code_t wholememory_get_local_node_memory(void** local_ptr,
+                                                           size_t* local_size,
+                                                           size_t* local_offset,
+                                                           wholememory_handle_t wholememory_handle)
+{
+  return wholememory::get_local_node_memory_from_handle(
     local_ptr, local_size, local_offset, wholememory_handle);
 }
 

--- a/cpp/src/wholememory/wholememory.cpp
+++ b/cpp/src/wholememory/wholememory.cpp
@@ -137,6 +137,18 @@ wholememory_error_code_t wholememory_get_communicator(wholememory_comm_t* comm,
   return wholememory::get_communicator_from_handle(comm, wholememory_handle);
 }
 
+wholememory_error_code_t wholememory_get_local_communicator(wholememory_comm_t* comm,
+                                                            wholememory_handle_t wholememory_handle)
+{
+  return wholememory::get_local_communicator_from_handle(comm, wholememory_handle);
+}
+
+wholememory_error_code_t wholememory_get_cross_communicator(wholememory_comm_t* comm,
+                                                            wholememory_handle_t wholememory_handle)
+{
+  return wholememory::get_cross_communicator_from_handle(comm, wholememory_handle);
+}
+
 wholememory_memory_type_t wholememory_get_memory_type(wholememory_handle_t wholememory_handle)
 {
   return wholememory::get_memory_type(wholememory_handle);

--- a/cpp/src/wholememory/wholememory.cpp
+++ b/cpp/src/wholememory/wholememory.cpp
@@ -185,15 +185,6 @@ wholememory_error_code_t wholememory_get_local_memory(void** local_ptr,
     local_ptr, local_size, local_offset, wholememory_handle);
 }
 
-wholememory_error_code_t wholememory_get_local_node_memory(void** local_ptr,
-                                                           size_t* local_size,
-                                                           size_t* local_offset,
-                                                           wholememory_handle_t wholememory_handle)
-{
-  return wholememory::get_local_node_memory_from_handle(
-    local_ptr, local_size, local_offset, wholememory_handle);
-}
-
 wholememory_error_code_t wholememory_get_rank_memory(void** rank_memory_ptr,
                                                      size_t* rank_memory_size,
                                                      size_t* rank_memory_offset,

--- a/cpp/src/wholememory_ops/functions/bucket_ids_for_hierarchy_func.cu
+++ b/cpp/src/wholememory_ops/functions/bucket_ids_for_hierarchy_func.cu
@@ -1,0 +1,386 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <cassert>
+#include <cstdint>
+
+#include <cub/cub.cuh>
+#include <cub/device/device_radix_sort.cuh>
+#include <thrust/sequence.h>
+#include <thrust/unique.h>
+
+#include <wholememory/wholememory.h>
+
+#include "cuda_macros.hpp"
+#include "error.hpp"
+#include "logger.hpp"
+#include "wholememory/integer_utils.hpp"
+#include "wholememory_ops/register.hpp"
+#include "wholememory_ops/temp_memory_handle.hpp"
+#include <wholememory_ops/thrust_allocator.hpp>
+
+namespace wholememory_ops {
+
+template <typename IndexT, int CROSS_OR_LOCAL = 0>
+__global__ void bucket_ids_for_hierarchy_kernel(const IndexT* indices,
+                                                size_t indice_count,
+                                                int64_t* dev_rank_id_count_ptr,
+                                                size_t embedding_entry_count_per_rank,
+                                                int local_size,
+                                                int bucket_size)
+{
+  extern __shared__ int rank_count_shared[];
+  for (int idx = threadIdx.x; idx < bucket_size; idx += blockDim.x) {
+    rank_count_shared[idx] = 0;
+  }
+  __syncthreads();
+  for (int idx = threadIdx.x + blockIdx.x * blockDim.x; idx < indice_count;
+       idx += blockDim.x * gridDim.x) {
+    IndexT node_idx = indices[idx];
+    if (node_idx < 0) continue;
+    int rank   = node_idx / embedding_entry_count_per_rank;
+    int bucket = 0;
+    if (CROSS_OR_LOCAL == 0)  // bucket cross ranks
+      bucket = rank % local_size;
+    else  // bucket local ranks
+      bucket = rank / local_size;
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 700
+    atomicAdd_block(&rank_count_shared[bucket], 1);
+#else
+    atomicAdd(&rank_count_shared[bucket], 1);
+#endif
+  }
+  __syncthreads();
+  for (int idx = threadIdx.x; idx < bucket_size; idx += blockDim.x) {
+    atomicAdd(reinterpret_cast<unsigned long long*>(dev_rank_id_count_ptr) + idx,
+              static_cast<unsigned long long>(rank_count_shared[idx]));
+  }
+}
+
+template <typename IndexT>
+void bucket_ids_for_hierarchy_temp_func(const void* indices,
+                                        wholememory_array_description_t indice_desc,
+                                        int64_t* dev_rank_id_count_ptr,
+                                        size_t embedding_entry_count_per_rank,
+                                        int local_size,
+                                        int cross_size,
+                                        int bucket_cross_or_local,
+                                        int sm_count,
+                                        cudaStream_t stream)
+{
+  static constexpr int BLOCK_SIZE = 128;
+  int block_count           = wholememory::div_rounding_up_unsafe(indice_desc.size, BLOCK_SIZE);
+  block_count               = std::min(block_count, sm_count * 4);
+  const IndexT* indices_ptr = static_cast<const IndexT*>(indices);
+  indices_ptr += indice_desc.storage_offset;
+
+  if (bucket_cross_or_local == 0) {
+    int bucket_size = local_size;
+    cudaMemsetAsync(dev_rank_id_count_ptr, 0, sizeof(int64_t) * bucket_size, stream);
+    bucket_ids_for_hierarchy_kernel<IndexT, 0>
+      <<<block_count, BLOCK_SIZE, sizeof(int) * bucket_size, stream>>>(
+        indices_ptr,
+        indice_desc.size,
+        dev_rank_id_count_ptr,
+        embedding_entry_count_per_rank,
+        local_size,
+        bucket_size);
+  } else {
+    int bucket_size = cross_size;
+    cudaMemsetAsync(dev_rank_id_count_ptr, 0, sizeof(int64_t) * bucket_size, stream);
+    bucket_ids_for_hierarchy_kernel<IndexT, 1>
+      <<<block_count, BLOCK_SIZE, sizeof(int) * bucket_size, stream>>>(
+        indices_ptr,
+        indice_desc.size,
+        dev_rank_id_count_ptr,
+        embedding_entry_count_per_rank,
+        local_size,
+        bucket_size);
+  }
+}
+
+REGISTER_DISPATCH_ONE_TYPE(BucketIdsForHierarchy, bucket_ids_for_hierarchy_temp_func, SINT3264)
+
+template <typename IndexT>
+__global__ void reorder_ids_for_hierarchy_kernel(const IndexT* indices,
+                                                 size_t indice_count,
+                                                 IndexT* dev_bucket_indices,
+                                                 IndexT* dev_indice_map,
+                                                 const int64_t* dev_rank_id_offset_ptr,
+                                                 size_t embedding_entry_count_per_rank,
+                                                 int local_size,
+                                                 int64_t* dev_bucket_atomic_add_ptr)
+{
+  int nbucket                      = local_size;
+  constexpr size_t shared_mem_size = 24576;
+  __shared__ char shared_mem[shared_mem_size];
+  int* block_bucket_count_shared      = reinterpret_cast<int*>(shared_mem);
+  int* block_bucket_atomic_add_shared = reinterpret_cast<int*>(shared_mem) + nbucket;
+  IndexT* block_bucket_offset_shared =
+    reinterpret_cast<IndexT*>(shared_mem + 2 * sizeof(int) * nbucket);
+  IndexT* global_bucket_offset_shared = block_bucket_offset_shared + nbucket;
+  size_t buffer_size =
+    (shared_mem_size - nbucket * 2 * (sizeof(IndexT) + sizeof(int))) / sizeof(IndexT) / 2;
+  buffer_size = (buffer_size / blockDim.x) * blockDim.x;
+  assert(buffer_size > 0);
+
+  IndexT* buffer_load  = global_bucket_offset_shared + nbucket;
+  IndexT* buffer_store = buffer_load + buffer_size;
+
+  int warp_idx = threadIdx.x / warpSize;
+  int lane_idx = threadIdx.x % warpSize;
+  int nwarp    = blockDim.x / warpSize;
+  for (IndexT load_offset = buffer_size * blockIdx.x; load_offset < indice_count;
+       load_offset += gridDim.x * buffer_size) {
+    for (int i = threadIdx.x; i < nbucket; i += blockDim.x) {
+      block_bucket_count_shared[i]      = 0;
+      block_bucket_atomic_add_shared[i] = 0;
+    }
+    __syncthreads();
+    for (IndexT i = threadIdx.x; i < buffer_size; i += blockDim.x) {
+      IndexT load_idx = i + load_offset;
+      if (load_idx >= indice_count) break;
+      IndexT indice = indices[load_idx];
+
+      buffer_load[i] = indice;
+      int bucket_idx = (indice / embedding_entry_count_per_rank) % local_size;
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 700
+      atomicAdd_block(&block_bucket_count_shared[bucket_idx], 1);
+#else
+      atomicAdd(&block_bucket_count_shared[bucket_idx], 1);
+#endif
+    }
+    __syncthreads();
+    if (threadIdx.x == blockDim.x - 1) {
+      IndexT bucket_offset_tmp = 0;
+      for (int bi = 0; bi < nbucket; bi++) {
+        block_bucket_offset_shared[bi] = bucket_offset_tmp;
+        bucket_offset_tmp += block_bucket_count_shared[bi];
+      }
+    }
+    if (threadIdx.x < nbucket) {
+      int bucket_idx = threadIdx.x;
+      global_bucket_offset_shared[bucket_idx] =
+        atomicAdd(reinterpret_cast<unsigned long long*>(dev_bucket_atomic_add_ptr) + bucket_idx,
+                  block_bucket_count_shared[bucket_idx]);
+    }
+    __syncthreads();
+    for (IndexT i = threadIdx.x; i < buffer_size; i += blockDim.x) {
+      IndexT indice   = buffer_load[i];
+      IndexT load_idx = i + load_offset;
+      if (load_idx >= indice_count) break;
+      int bucket_idx = (indice / embedding_entry_count_per_rank) % local_size;
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 700
+      int block_bucket_inc = atomicAdd_block(&block_bucket_atomic_add_shared[bucket_idx], 1);
+#else
+      int block_bucket_inc = atomicAdd(&block_bucket_atomic_add_shared[bucket_idx], 1);
+#endif
+      buffer_store[block_bucket_offset_shared[bucket_idx] + block_bucket_inc] = indice;
+      dev_indice_map[load_idx] = dev_rank_id_offset_ptr[bucket_idx] +
+                                 global_bucket_offset_shared[bucket_idx] + block_bucket_inc;
+    }
+    __syncthreads();
+    for (int bucket_idx = warp_idx; bucket_idx < nbucket; bucket_idx += nwarp) {
+      int bucket_length = block_bucket_count_shared[bucket_idx];
+      IndexT global_bucket_offset =
+        dev_rank_id_offset_ptr[bucket_idx] + global_bucket_offset_shared[bucket_idx];
+      for (int idx = lane_idx; idx < bucket_length; idx += warpSize) {
+        dev_bucket_indices[global_bucket_offset + idx] =
+          buffer_store[block_bucket_offset_shared[bucket_idx] + idx];
+      }
+    }
+    __syncthreads();
+  }
+}
+
+template <typename IndexT>
+void reorder_ids_for_hierarchy_temp_func(const void* indices,
+                                         wholememory_array_description_t indice_desc,
+                                         void* dev_bucket_indices,
+                                         void* dev_indice_map,
+                                         const int64_t* dev_rank_id_count_ptr,
+                                         size_t embedding_entry_count_per_rank,
+                                         int local_size,
+                                         wm_thrust_allocator* p_thrust_allocator,
+                                         wholememory_env_func_t* p_env_fns,
+                                         int sm_count,
+                                         cudaStream_t stream)
+{
+  WHOLEMEMORY_CHECK(indice_desc.storage_offset == 0);
+  WHOLEMEMORY_CHECK(indice_desc.dtype == WHOLEMEMORY_DT_INT ||
+                    indice_desc.dtype == WHOLEMEMORY_DT_INT64);
+
+  temp_memory_handle dev_rank_id_offset_handle(p_env_fns);
+  int64_t* dev_rank_id_offset_ptr = static_cast<int64_t*>(
+    dev_rank_id_offset_handle.device_malloc(local_size, WHOLEMEMORY_DT_INT64));
+  void* cub_temp_storage    = NULL;
+  size_t temp_storage_bytes = 0;
+  cub::DeviceScan::ExclusiveSum(cub_temp_storage,
+                                temp_storage_bytes,
+                                dev_rank_id_count_ptr,
+                                dev_rank_id_offset_ptr,
+                                local_size,
+                                stream);
+  cub_temp_storage = p_thrust_allocator->allocate(temp_storage_bytes);
+  cub::DeviceScan::ExclusiveSum(cub_temp_storage,
+                                temp_storage_bytes,
+                                dev_rank_id_count_ptr,
+                                dev_rank_id_offset_ptr,
+                                local_size,
+                                stream);
+  p_thrust_allocator->deallocate(reinterpret_cast<char*>(cub_temp_storage), temp_storage_bytes);
+
+  temp_memory_handle dev_bucket_atomic_add_handle(p_env_fns);
+  int64_t* dev_bucket_atomic_add_ptr = static_cast<int64_t*>(
+    dev_bucket_atomic_add_handle.device_malloc(local_size, WHOLEMEMORY_DT_INT64));
+  cudaMemsetAsync((void*)dev_bucket_atomic_add_ptr, 0, sizeof(int64_t) * local_size, stream);
+  static constexpr int BLOCK_SIZE = 128;
+  int block_count = wholememory::div_rounding_up_unsafe(indice_desc.size, BLOCK_SIZE);
+  block_count     = std::min(block_count, sm_count * 4);
+
+  reorder_ids_for_hierarchy_kernel<<<block_count, BLOCK_SIZE, 0, stream>>>(
+    static_cast<const IndexT*>(indices),
+    indice_desc.size,
+    static_cast<IndexT*>(dev_bucket_indices),
+    static_cast<IndexT*>(dev_indice_map),
+    dev_rank_id_offset_ptr,
+    embedding_entry_count_per_rank,
+    local_size,
+    dev_bucket_atomic_add_ptr);
+}
+
+REGISTER_DISPATCH_ONE_TYPE(ReorderIdsForHierarchy, reorder_ids_for_hierarchy_temp_func, SINT3264)
+
+wholememory_error_code_t bucket_and_reorder_ids_for_hierarchy_func(
+  void* indices,
+  wholememory_array_description_t indice_desc,
+  void* dev_bucket_indices,
+  void* dev_indice_map,
+  int64_t* host_bucket_id_count,
+  size_t embedding_entry_count_per_rank,
+  wholememory_comm_t wm_global_comm,
+  wholememory_comm_t wm_local_comm,
+  wm_thrust_allocator* p_thrust_allocator,
+  wholememory_env_func_t* p_env_fns,
+  cudaStream_t stream)
+{
+  if (indice_desc.size == 0) { return WHOLEMEMORY_SUCCESS; }
+  int world_size, local_size;
+  WHOLEMEMORY_RETURN_ON_FAIL(wholememory_communicator_get_size(&world_size, wm_global_comm));
+  WHOLEMEMORY_RETURN_ON_FAIL(wholememory_communicator_get_size(&local_size, wm_local_comm));
+  WHOLEMEMORY_CHECK_NOTHROW(world_size % local_size == 0);
+
+  constexpr int K_DEFAULT_SM_COUNT = 108;
+  auto prop                        = get_device_prop(-1);
+  int sm_count = (prop != nullptr) ? prop->multiProcessorCount : K_DEFAULT_SM_COUNT;
+  temp_memory_handle dev_rank_id_count_handle(p_env_fns);
+  int64_t* dev_rank_id_count_ptr =
+    static_cast<int64_t*>(dev_rank_id_count_handle.device_malloc(local_size, WHOLEMEMORY_DT_INT64));
+  cudaMemsetAsync((void*)dev_rank_id_count_ptr, 0, sizeof(int64_t) * local_size, stream);
+  try {
+    DISPATCH_ONE_TYPE(indice_desc.dtype,
+                      BucketIdsForHierarchy,
+                      indices,
+                      indice_desc,
+                      dev_rank_id_count_ptr,
+                      embedding_entry_count_per_rank,
+                      local_size,
+                      0,  // ignore
+                      0,
+                      sm_count,
+                      stream);
+  } catch (wholememory::cuda_error& wce) {
+    WHOLEMEMORY_ERROR("bucket_ids_for_hierarchy_func CUDA LOGIC Error %s\n", wce.what());
+    return WHOLEMEMORY_CUDA_ERROR;
+  }
+  WM_CUDA_CHECK_NO_THROW(cudaMemcpyAsync(host_bucket_id_count,
+                                         dev_rank_id_count_ptr,
+                                         local_size * sizeof(int64_t),
+                                         cudaMemcpyDeviceToHost,
+                                         stream));
+  try {
+    DISPATCH_ONE_TYPE(indice_desc.dtype,
+                      ReorderIdsForHierarchy,
+                      indices,
+                      indice_desc,
+                      dev_bucket_indices,
+                      dev_indice_map,
+                      dev_rank_id_count_ptr,
+                      embedding_entry_count_per_rank,
+                      local_size,
+                      p_thrust_allocator,
+                      p_env_fns,
+                      sm_count,
+                      stream);
+  } catch (wholememory::cuda_error& wce) {
+    WHOLEMEMORY_ERROR("reorder_ids_for_hierarchy CUDA LOGIC Error %s\n", wce.what());
+    return WHOLEMEMORY_CUDA_ERROR;
+  } catch (wholememory::logic_error& wle) {
+    WHOLEMEMORY_ERROR("reorder_ids_for_hierarchy LOGIC Error %s\n", wle.what());
+    return WHOLEMEMORY_LOGIC_ERROR;
+  } catch (...) {
+    return WHOLEMEMORY_UNKNOW_ERROR;
+  }
+  return WHOLEMEMORY_SUCCESS;
+}
+
+wholememory_error_code_t bucket_local_ids_func(void* indices,
+                                               wholememory_array_description_t indice_desc,
+                                               int64_t* host_bucket_id_count,
+                                               size_t embedding_entry_count_per_rank,
+                                               wholememory_comm_t wm_local_comm,
+                                               wholememory_comm_t wm_cross_comm,
+                                               wm_thrust_allocator* p_thrust_allocator,
+                                               wholememory_env_func_t* p_env_fns,
+                                               cudaStream_t stream)
+{
+  if (indice_desc.size == 0) { return WHOLEMEMORY_SUCCESS; }
+  int cross_size, local_size;
+  WHOLEMEMORY_RETURN_ON_FAIL(wholememory_communicator_get_size(&cross_size, wm_cross_comm));
+  WHOLEMEMORY_RETURN_ON_FAIL(wholememory_communicator_get_size(&local_size, wm_local_comm));
+
+  constexpr int K_DEFAULT_SM_COUNT = 108;
+  auto prop                        = get_device_prop(-1);
+  int sm_count = (prop != nullptr) ? prop->multiProcessorCount : K_DEFAULT_SM_COUNT;
+  temp_memory_handle dev_rank_id_count_handle(p_env_fns);
+  int64_t* dev_rank_id_count_ptr =
+    static_cast<int64_t*>(dev_rank_id_count_handle.device_malloc(cross_size, WHOLEMEMORY_DT_INT64));
+  cudaMemsetAsync((void*)dev_rank_id_count_ptr, 0, sizeof(int64_t) * cross_size, stream);
+  try {
+    DISPATCH_ONE_TYPE(indice_desc.dtype,
+                      BucketIdsForHierarchy,
+                      indices,
+                      indice_desc,
+                      dev_rank_id_count_ptr,
+                      embedding_entry_count_per_rank,
+                      local_size,
+                      cross_size,
+                      1,
+                      sm_count,
+                      stream);
+  } catch (wholememory::cuda_error& wce) {
+    WHOLEMEMORY_ERROR("bucket_ids_for_hierarchy CUDA LOGIC Error %s\n", wce.what());
+    return WHOLEMEMORY_CUDA_ERROR;
+  }
+  WM_CUDA_CHECK_NO_THROW(cudaMemcpyAsync(host_bucket_id_count,
+                                         dev_rank_id_count_ptr,
+                                         cross_size * sizeof(int64_t),
+                                         cudaMemcpyDeviceToHost,
+                                         stream));
+  WM_CUDA_CHECK(cudaGetLastError());
+  return WHOLEMEMORY_SUCCESS;
+}
+
+}  // namespace wholememory_ops

--- a/cpp/src/wholememory_ops/functions/bucket_ids_for_hierarchy_func.h
+++ b/cpp/src/wholememory_ops/functions/bucket_ids_for_hierarchy_func.h
@@ -29,7 +29,7 @@ wholememory_error_code_t bucket_and_reorder_ids_for_hierarchy_func(
   void* dev_bucket_indices,
   void* dev_indice_map,
   int64_t* host_bucket_id_count,
-  size_t embedding_entry_count_per_rank,
+  size_t* dev_embedding_entry_offsets,
   wholememory_comm_t wm_global_comm,
   wholememory_comm_t wm_local_comm,
   int bucket_cross_or_local,  // 0: cross, 1: local
@@ -40,7 +40,7 @@ wholememory_error_code_t bucket_and_reorder_ids_for_hierarchy_func(
 wholememory_error_code_t bucket_local_ids_func(void* indices,
                                                wholememory_array_description_t indice_desc,
                                                int64_t* host_bucket_id_count,
-                                               size_t embedding_entry_count_per_rank,
+                                               size_t* dev_embedding_entry_offsets,
                                                wholememory_comm_t wm_local_comm,
                                                wholememory_comm_t wm_cross_comm,
                                                wm_thrust_allocator* p_thrust_allocator,

--- a/cpp/src/wholememory_ops/functions/bucket_ids_for_hierarchy_func.h
+++ b/cpp/src/wholememory_ops/functions/bucket_ids_for_hierarchy_func.h
@@ -32,6 +32,7 @@ wholememory_error_code_t bucket_and_reorder_ids_for_hierarchy_func(
   size_t embedding_entry_count_per_rank,
   wholememory_comm_t wm_global_comm,
   wholememory_comm_t wm_local_comm,
+  int bucket_cross_or_local,  // 0: cross, 1: local
   wm_thrust_allocator* p_thrust_allocator,
   wholememory_env_func_t* p_env_fns,
   cudaStream_t stream);

--- a/cpp/src/wholememory_ops/functions/bucket_ids_for_hierarchy_func.h
+++ b/cpp/src/wholememory_ops/functions/bucket_ids_for_hierarchy_func.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <wholememory/tensor_description.h>
+#include <wholememory/wholememory.h>
+#include <wholememory_ops/thrust_allocator.hpp>
+
+#include "wholememory_ops/temp_memory_handle.hpp"
+
+namespace wholememory_ops {
+
+wholememory_error_code_t bucket_and_reorder_ids_for_hierarchy_func(
+  void* indices,
+  wholememory_array_description_t indice_desc,
+  void* dev_bucket_indices,
+  void* dev_indice_map,
+  int64_t* host_bucket_id_count,
+  size_t embedding_entry_count_per_rank,
+  wholememory_comm_t wm_global_comm,
+  wholememory_comm_t wm_local_comm,
+  wm_thrust_allocator* p_thrust_allocator,
+  wholememory_env_func_t* p_env_fns,
+  cudaStream_t stream);
+
+wholememory_error_code_t bucket_local_ids_func(void* indices,
+                                               wholememory_array_description_t indice_desc,
+                                               int64_t* host_bucket_id_count,
+                                               size_t embedding_entry_count_per_rank,
+                                               wholememory_comm_t wm_local_comm,
+                                               wholememory_comm_t wm_cross_comm,
+                                               wm_thrust_allocator* p_thrust_allocator,
+                                               wholememory_env_func_t* p_env_fns,
+                                               cudaStream_t stream);
+
+}  // namespace wholememory_ops

--- a/cpp/src/wholememory_ops/functions/sort_unique_ids_for_hierarchy_func.cu
+++ b/cpp/src/wholememory_ops/functions/sort_unique_ids_for_hierarchy_func.cu
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sort_unique_ids_for_hierarchy_func.h"
+#include "sort_unique_indices_func.h"
+
+#include <cassert>
+#include <cstdint>
+
+#include <cub/cub.cuh>
+#include <cub/device/device_radix_sort.cuh>
+#include <thrust/sequence.h>
+#include <thrust/unique.h>
+
+#include <wholememory/wholememory.h>
+
+#include "cuda_macros.hpp"
+#include "error.hpp"
+#include "logger.hpp"
+#include "wholememory/communicator.hpp"
+#include "wholememory/integer_utils.hpp"
+#include "wholememory_ops/register.hpp"
+#include "wholememory_ops/temp_memory_handle.hpp"
+#include <wholememory_ops/thrust_allocator.hpp>
+
+namespace wholememory_ops {
+
+template <typename IndexT>
+__global__ void SortUniqueIndiceMapKernel(IndexT* indice_map,
+                                          size_t indice_count,
+                                          const IndexT* sort_raw_indices,
+                                          const int* unique_count_ptr,
+                                          const IndexT* unique_offset_ptr,
+                                          size_t num_unique)
+{
+  for (int idx = threadIdx.x + blockIdx.x * blockDim.x; idx < indice_count;
+       idx += blockDim.x * gridDim.x) {
+    if (idx >= num_unique) break;
+    IndexT offset = unique_offset_ptr[idx];
+    int count     = unique_count_ptr[idx];
+    for (IndexT i = offset; i < offset + count; i++) {
+      indice_map[sort_raw_indices[i]] = idx;
+    }
+  }
+}
+
+template <typename IndexT>
+void SortUniqueIndicesMapTempFunc(void* indice_map,
+                                  wholememory_array_description_t indice_desc,
+                                  const void* sort_raw_indices,
+                                  const int* unique_count_ptr,
+                                  size_t num_unique,
+                                  wm_thrust_allocator* p_thrust_allocator,
+                                  wholememory_env_func_t* p_env_fns,
+                                  cudaStream_t stream)
+{
+  static constexpr int BLOCK_SIZE = 128;
+  int block_count                 = wholememory::div_rounding_up_unsafe(num_unique, BLOCK_SIZE);
+
+  temp_memory_handle dev_unique_offset_handle(p_env_fns);
+  IndexT* unique_offset_ptr =
+    static_cast<IndexT*>(dev_unique_offset_handle.device_malloc(num_unique, indice_desc.dtype));
+  IndexT* indice_map_ptr             = static_cast<IndexT*>(indice_map);
+  const IndexT* sort_raw_indices_ptr = static_cast<const IndexT*>(sort_raw_indices);
+
+  void* cub_temp_storage    = NULL;
+  size_t temp_storage_bytes = 0;
+  cub::DeviceScan::ExclusiveSum(
+    cub_temp_storage, temp_storage_bytes, unique_count_ptr, unique_offset_ptr, num_unique, stream);
+  cub_temp_storage = p_thrust_allocator->allocate(temp_storage_bytes);
+  cub::DeviceScan::ExclusiveSum(
+    cub_temp_storage, temp_storage_bytes, unique_count_ptr, unique_offset_ptr, num_unique, stream);
+  SortUniqueIndiceMapKernel<<<block_count, BLOCK_SIZE, 0, stream>>>(indice_map_ptr,
+                                                                    indice_desc.size,
+                                                                    sort_raw_indices_ptr,
+                                                                    unique_count_ptr,
+                                                                    unique_offset_ptr,
+                                                                    num_unique);
+  p_thrust_allocator->deallocate(reinterpret_cast<char*>(cub_temp_storage), temp_storage_bytes);
+}
+
+REGISTER_DISPATCH_ONE_TYPE(SortUniqueIndicesMapTempFunc, SortUniqueIndicesMapTempFunc, SINT3264)
+
+wholememory_error_code_t sort_unique_ids_for_hierarchy_func(
+  void* indices,
+  wholememory_array_description_t indice_desc,
+  temp_memory_handle* output_indices_handle,
+  wholememory_array_description_t* output_indices_desc,
+  temp_memory_handle* dev_indice_map_handle,
+  wm_thrust_allocator* p_thrust_allocator,
+  wholememory_env_func_t* p_env_fns,
+  cudaStream_t stream)
+{
+  if (indice_desc.size == 0) {
+    *output_indices_desc = wholememory_create_array_desc(0, 0, indice_desc.dtype);
+    return WHOLEMEMORY_SUCCESS;
+  }
+  int num_runs = 0;
+  temp_memory_handle unique_count_handle(p_env_fns);
+  temp_memory_handle dev_sort_raw_indices_handle(p_env_fns);
+  void* dev_sort_raw_indices_ptr =
+    dev_sort_raw_indices_handle.device_malloc(indice_desc.size, indice_desc.dtype);
+  sort_unique_indices_func(indices,
+                           indice_desc,
+                           dev_sort_raw_indices_ptr,
+                           &num_runs,
+                           output_indices_handle,
+                           &unique_count_handle,
+                           p_thrust_allocator,
+                           p_env_fns,
+                           stream);
+  *output_indices_desc = wholememory_create_array_desc(num_runs, 0, indice_desc.dtype);
+  void* dev_indice_map_ptr =
+    dev_indice_map_handle->device_malloc(indice_desc.size, indice_desc.dtype);
+  WM_CUDA_CHECK(cudaGetLastError());
+  try {
+    DISPATCH_ONE_TYPE(indice_desc.dtype,
+                      SortUniqueIndicesMapTempFunc,
+                      dev_indice_map_ptr,
+                      indice_desc,
+                      dev_sort_raw_indices_ptr,
+                      static_cast<int*>(unique_count_handle.pointer()),
+                      num_runs,
+                      p_thrust_allocator,
+                      p_env_fns,
+                      stream);
+  } catch (...) {
+    WHOLEMEMORY_FAIL_NOTHROW("map indices failed");
+  }
+  return WHOLEMEMORY_SUCCESS;
+}
+
+}  // namespace wholememory_ops

--- a/cpp/src/wholememory_ops/functions/sort_unique_ids_for_hierarchy_func.h
+++ b/cpp/src/wholememory_ops/functions/sort_unique_ids_for_hierarchy_func.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "wholememory_ops/temp_memory_handle.hpp"
+#include <wholememory/tensor_description.h>
+#include <wholememory/wholememory.h>
+#include <wholememory_ops/thrust_allocator.hpp>
+
+namespace wholememory_ops {
+
+wholememory_error_code_t sort_unique_ids_for_hierarchy_func(
+  void* indices,
+  wholememory_array_description_t indice_desc,
+  temp_memory_handle* output_indices_handle,
+  wholememory_array_description_t* output_indices_desc,
+  temp_memory_handle* dev_indice_map_handle,  // indice_desc
+  wm_thrust_allocator* p_thrust_allocator,
+  wholememory_env_func_t* p_env_fns,
+  cudaStream_t stream);
+
+}  // namespace wholememory_ops

--- a/cpp/src/wholememory_ops/functions/sort_unique_indices_func.cu
+++ b/cpp/src/wholememory_ops/functions/sort_unique_indices_func.cu
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "sort_indices_func.h"
+#include "sort_unique_indices_func.h"
+
+#include <cub/cub.cuh>
+#include <cub/device/device_radix_sort.cuh>
+#include <thrust/sequence.h>
+
+#include "cuda_macros.hpp"
+#include "error.hpp"
+#include "logger.hpp"
+#include "wholememory_ops/register.hpp"
+
+namespace wholememory_ops {
+
+template <typename IndexT>
+void SortUniqueIndicesTempFunc(const void* indices,
+                               wholememory_array_description_t indice_desc,
+                               void* sort_raw_indices,
+                               int* num_runs,
+                               temp_memory_handle* unique_indices_handle,
+                               temp_memory_handle* unique_count_handle,
+                               wm_thrust_allocator* p_thrust_allocator,
+                               wholememory_env_func_t* p_env_fns,
+                               cudaStream_t stream)
+{
+  if (indice_desc.size == 0) return;
+  wm_thrust_allocator& allocator = *p_thrust_allocator;
+  WHOLEMEMORY_CHECK_NOTHROW(indice_desc.storage_offset == 0);
+  temp_memory_handle sorted_indices_handle(p_env_fns);
+  sorted_indices_handle.device_malloc(indice_desc.size, indice_desc.dtype);
+  IndexT* sorted_indices = static_cast<IndexT*>(sorted_indices_handle.pointer());
+
+  sort_indices_func(
+    indices, indice_desc, sorted_indices, sort_raw_indices, p_thrust_allocator, p_env_fns, stream);
+
+  unique_indices_handle->device_malloc(indice_desc.size, indice_desc.dtype);
+  unique_count_handle->device_malloc(indice_desc.size, WHOLEMEMORY_DT_INT);
+  IndexT* unique_indices = static_cast<IndexT*>(unique_indices_handle->pointer());
+  int* unique_counts     = static_cast<int*>(unique_count_handle->pointer());
+  temp_memory_handle number_runs_handle(p_env_fns);
+  number_runs_handle.device_malloc(1, WHOLEMEMORY_DT_INT);
+  int* number_runs          = static_cast<int*>(number_runs_handle.pointer());
+  void* cub_temp_storage    = nullptr;
+  size_t temp_storage_bytes = 0;
+  cub::DeviceRunLengthEncode::Encode(cub_temp_storage,
+                                     temp_storage_bytes,
+                                     sorted_indices,
+                                     unique_indices,
+                                     unique_counts,
+                                     number_runs,
+                                     indice_desc.size,
+                                     stream);
+  cub_temp_storage = allocator.allocate(temp_storage_bytes);
+  cub::DeviceRunLengthEncode::Encode(cub_temp_storage,
+                                     temp_storage_bytes,
+                                     sorted_indices,
+                                     unique_indices,
+                                     unique_counts,
+                                     number_runs,
+                                     indice_desc.size,
+                                     stream);
+  WM_CUDA_CHECK_NO_THROW(
+    cudaMemcpyAsync(num_runs, number_runs, sizeof(int), cudaMemcpyDeviceToHost, stream));
+}
+
+REGISTER_DISPATCH_ONE_TYPE(SortUniqueIndicesTempFunc, SortUniqueIndicesTempFunc, SINT3264)
+
+wholememory_error_code_t sort_unique_indices_func(const void* indices,
+                                                  wholememory_array_description_t indice_desc,
+                                                  void* sort_raw_indices,
+                                                  int* num_runs,
+                                                  temp_memory_handle* unique_indices_handle,
+                                                  temp_memory_handle* unique_count_handle,
+                                                  wm_thrust_allocator* p_thrust_allocator,
+                                                  wholememory_env_func_t* p_env_fns,
+                                                  cudaStream_t stream)
+{
+  try {
+    DISPATCH_ONE_TYPE(indice_desc.dtype,
+                      SortUniqueIndicesTempFunc,
+                      indices,
+                      indice_desc,
+                      sort_raw_indices,
+                      num_runs,
+                      unique_indices_handle,
+                      unique_count_handle,
+                      p_thrust_allocator,
+                      p_env_fns,
+                      stream);
+  } catch (wholememory::cuda_error& wce) {
+    WHOLEMEMORY_ERROR("sort_unique_indices_func CUDA LOGIC Error %s\n", wce.what());
+    return WHOLEMEMORY_CUDA_ERROR;
+  } catch (wholememory::logic_error& wle) {
+    WHOLEMEMORY_ERROR("sort_unique_indices_func LOGIC Error %s\n", wle.what());
+    return WHOLEMEMORY_LOGIC_ERROR;
+  } catch (...) {
+    return WHOLEMEMORY_UNKNOW_ERROR;
+  }
+  return WHOLEMEMORY_SUCCESS;
+}
+
+}  // namespace wholememory_ops

--- a/cpp/src/wholememory_ops/functions/sort_unique_indices_func.h
+++ b/cpp/src/wholememory_ops/functions/sort_unique_indices_func.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <wholememory/tensor_description.h>
+#include <wholememory/wholememory.h>
+
+#include <wholememory_ops/temp_memory_handle.hpp>
+#include <wholememory_ops/thrust_allocator.hpp>
+
+namespace wholememory_ops {
+
+wholememory_error_code_t sort_unique_indices_func(const void* indices,
+                                                  wholememory_array_description_t indice_desc,
+                                                  void* sort_raw_indices,
+                                                  int* num_runs,
+                                                  temp_memory_handle* unique_indices_handle,
+                                                  temp_memory_handle* unique_count_handle,
+                                                  wm_thrust_allocator* p_thrust_allocator,
+                                                  wholememory_env_func_t* p_env_fns,
+                                                  cudaStream_t stream);
+
+}  // namespace wholememory_ops

--- a/cpp/src/wholememory_ops/gather_op.cpp
+++ b/cpp/src/wholememory_ops/gather_op.cpp
@@ -93,6 +93,19 @@ wholememory_error_code_t wholememory_gather(wholememory_tensor_t wholememory_ten
       gather_sms);
   }
 
+  if (has_handle && memory_type == WHOLEMEMORY_MT_HIERARCHY) {
+    return wholememory_ops::wholememory_gather_hierarchy(
+      wholememory_tensor_get_memory_handle(wholememory_tensor),
+      matrix_description,
+      indices,
+      indices_desc,
+      output,
+      output_desc,
+      p_env_fns,
+      static_cast<cudaStream_t>(stream),
+      gather_sms);
+  }
+
   WHOLEMEMORY_EXPECTS_NOTHROW(!has_handle || memory_type == WHOLEMEMORY_MT_CHUNKED ||
                                 memory_type == WHOLEMEMORY_MT_CONTINUOUS,
                               "Memory type not supported.");

--- a/cpp/src/wholememory_ops/gather_op_impl.h
+++ b/cpp/src/wholememory_ops/gather_op_impl.h
@@ -42,6 +42,17 @@ wholememory_error_code_t wholememory_gather_nccl(wholememory_handle_t wholememor
                                                  cudaStream_t stream,
                                                  int gather_sms);
 
+wholememory_error_code_t wholememory_gather_hierarchy(
+  wholememory_handle_t wholememory_handle,
+  wholememory_matrix_description_t wholememory_desc,
+  void* indices,
+  wholememory_array_description_t indice_desc,
+  void* output,
+  wholememory_matrix_description_t output_desc,
+  wholememory_env_func_t* p_env_fns,
+  cudaStream_t stream,
+  int gather_sms);
+
 wholememory_error_code_t wholememory_gather_distributed(
   wholememory_handle_t wholememory_handle,
   wholememory_matrix_description_t wholememory_desc,

--- a/cpp/src/wholememory_ops/gather_op_impl_hierarchy.cu
+++ b/cpp/src/wholememory_ops/gather_op_impl_hierarchy.cu
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <cuda_runtime_api.h>
+
+#include <wholememory/env_func_ptrs.h>
+#include <wholememory/wholememory.h>
+
+#include "logger.hpp"
+#include "wholememory/communicator.hpp"
+#include "wholememory/memory_handle.hpp"
+#include "wholememory_ops/functions/bucket_ids_func.h"
+#include "wholememory_ops/functions/exchange_embeddings_nccl_func.h"
+#include "wholememory_ops/functions/exchange_ids_nccl_func.h"
+#include "wholememory_ops/functions/gather_scatter_func.h"
+#include "wholememory_ops/gather_op_impl.h"
+#include "wholememory_ops/temp_memory_handle.hpp"
+#include "wholememory_ops/thrust_allocator.hpp"
+
+namespace wholememory_ops {
+
+wholememory_error_code_t wholememory_gather_hierarchy(
+  wholememory_handle_t wholememory_handle,
+  wholememory_matrix_description_t wholememory_desc,
+  void* indices,
+  wholememory_array_description_t indice_desc,
+  void* output,
+  wholememory_matrix_description_t output_desc,
+  wholememory_env_func_t* p_env_fns,
+  cudaStream_t stream,
+  int gather_sms)
+{
+  try {
+    if (wholememory_desc.storage_offset < 0 ||
+        wholememory_desc.storage_offset + wholememory_desc.sizes[1] > wholememory_desc.stride) {
+      return WHOLEMEMORY_INVALID_INPUT;
+    }
+
+    wm_thrust_allocator thrust_allocator(p_env_fns);
+
+    size_t embedding_size_per_rank;
+    WHOLEMEMORY_RETURN_ON_FAIL(
+      wholememory_get_partition_plan(&embedding_size_per_rank, wholememory_handle));
+
+    size_t element_size         = wholememory_dtype_get_element_size(wholememory_desc.dtype);
+    size_t embedding_entry_size = element_size * wholememory_desc.stride;
+
+    WHOLEMEMORY_EXPECTS_NOTHROW(
+      embedding_size_per_rank % embedding_entry_size == 0,
+      "embedding_size_per_rank=%ld is not multiple of embedding_entry_size=%ldx%ld",
+      embedding_size_per_rank,
+      element_size,
+      wholememory_desc.stride);
+
+    size_t embedding_entry_count_per_rank = embedding_size_per_rank / embedding_entry_size;
+
+    wholememory_comm_t wm_comm;
+    WHOLEMEMORY_RETURN_ON_FAIL(wholememory_get_communicator(&wm_comm, wholememory_handle));
+
+    int world_size;
+    WHOLEMEMORY_RETURN_ON_FAIL(wholememory_communicator_get_size(&world_size, wm_comm));
+
+    temp_memory_handle host_rank_id_count(p_env_fns), host_recv_rank_id_count(p_env_fns);
+    int64_t* host_rank_id_count_ptr =
+      static_cast<int64_t*>(host_rank_id_count.host_malloc(world_size, WHOLEMEMORY_DT_INT64));
+    int64_t* host_recv_rank_id_count_ptr =
+      static_cast<int64_t*>(host_recv_rank_id_count.host_malloc(world_size, WHOLEMEMORY_DT_INT64));
+
+    temp_memory_handle dev_recv_indice_buffer(p_env_fns);
+    temp_memory_handle dev_raw_indice(p_env_fns);
+    int64_t* dev_raw_indice_ptr =
+      static_cast<int64_t*>(dev_raw_indice.device_malloc(indice_desc.size, WHOLEMEMORY_DT_INT64));
+
+    int64_t total_recv_count = 0;
+    WHOLEMEMORY_RETURN_ON_FAIL(bucket_and_exchange_ids_func(indices,
+                                                            indice_desc,
+                                                            host_recv_rank_id_count_ptr,
+                                                            host_rank_id_count_ptr,
+                                                            &dev_recv_indice_buffer,
+                                                            dev_raw_indice_ptr,
+                                                            embedding_entry_count_per_rank,
+                                                            wm_comm,
+                                                            &thrust_allocator,
+                                                            p_env_fns,
+                                                            stream));
+
+    // Local Gather
+    for (int i = 0; i < world_size; i++) {
+      total_recv_count += host_recv_rank_id_count_ptr[i];
+    }
+    size_t local_mem_offset, local_mem_size;
+    temp_memory_handle dev_local_gather_buffer(p_env_fns);
+    temp_memory_handle dev_embedding_recv_buffer(p_env_fns);
+    void* dev_local_gather_buffer_ptr = dev_local_gather_buffer.device_malloc(
+      wholememory_desc.sizes[1] * total_recv_count, output_desc.dtype);
+    void* dev_embedding_recv_buffer_ptr = dev_embedding_recv_buffer.device_malloc(
+      wholememory_desc.sizes[1] * indice_desc.size, output_desc.dtype);
+    void* local_fake_ptr = nullptr;
+    WHOLEMEMORY_RETURN_ON_FAIL(wholememory_get_local_memory(
+      &local_fake_ptr, &local_mem_size, &local_mem_offset, wholememory_handle));
+    local_fake_ptr = static_cast<char*>(local_fake_ptr) - local_mem_offset;
+    wholememory_gref_t local_fake_gref =
+      wholememory_create_continuous_global_reference(local_fake_ptr);
+    int64_t local_buffer_size[2] = {total_recv_count, wholememory_desc.sizes[1]};
+    wholememory_matrix_description_t local_gather_buffer_desc = wholememory_create_matrix_desc(
+      local_buffer_size, wholememory_desc.sizes[1], 0, output_desc.dtype);
+    auto dev_recv_indice_desc =
+      wholememory_create_array_desc(total_recv_count, 0, indice_desc.dtype);
+    WHOLEMEMORY_RETURN_ON_FAIL(gather_func(local_fake_gref,
+                                           wholememory_desc,
+                                           dev_recv_indice_buffer.pointer(),
+                                           dev_recv_indice_desc,
+                                           dev_local_gather_buffer_ptr,
+                                           local_gather_buffer_desc,
+                                           stream,
+                                           gather_sms));
+    // AllToAllV for embeddings
+    size_t embedding_size =
+      wholememory_desc.sizes[1] * wholememory_dtype_get_element_size(output_desc.dtype);
+    WHOLEMEMORY_RETURN_ON_FAIL(exchange_embeddings_nccl_func(dev_local_gather_buffer_ptr,
+                                                             host_recv_rank_id_count_ptr,
+                                                             host_rank_id_count_ptr,
+                                                             dev_embedding_recv_buffer_ptr,
+                                                             embedding_size,
+                                                             wm_comm,
+                                                             stream));
+    // Local reorder
+    int64_t total_need_indice_count = 0;
+    for (int i = 0; i < world_size; i++) {
+      total_need_indice_count += host_rank_id_count_ptr[i];
+    }
+    wholememory_gref_t output_gref = wholememory_create_continuous_global_reference(output);
+    wholememory_matrix_description_t local_recv_buffer_desc =
+      wholememory_create_matrix_desc(output_desc.sizes, output_desc.sizes[1], 0, output_desc.dtype);
+    local_recv_buffer_desc.sizes[0] = total_need_indice_count;
+    auto raw_indice_desc =
+      wholememory_create_array_desc(total_need_indice_count, 0, WHOLEMEMORY_DT_INT64);
+    WHOLEMEMORY_RETURN_ON_FAIL(scatter_func(dev_embedding_recv_buffer_ptr,
+                                            local_recv_buffer_desc,
+                                            dev_raw_indice_ptr,
+                                            raw_indice_desc,
+                                            output_gref,
+                                            output_desc,
+                                            stream));
+    WM_CUDA_CHECK(cudaGetLastError());
+    // WM_CUDA_CHECK(cudaStreamSynchronize(stream));
+  } catch (wholememory::cuda_error& wce) {
+    WHOLEMEMORY_ERROR("CUDA logic Error %s\n", wce.what());
+    return WHOLEMEMORY_CUDA_ERROR;
+  } catch (wholememory::logic_error& wle) {
+    WHOLEMEMORY_ERROR("LOGIC Error %s\n", wle.what());
+    return WHOLEMEMORY_LOGIC_ERROR;
+  } catch (...) {
+    return WHOLEMEMORY_UNKNOW_ERROR;
+  }
+
+  return WHOLEMEMORY_SUCCESS;
+}
+
+}  // namespace wholememory_ops

--- a/cpp/tests/wholememory_ops/wholememory_gather_tests.cu
+++ b/cpp/tests/wholememory_ops/wholememory_gather_tests.cu
@@ -300,9 +300,11 @@ INSTANTIATE_TEST_SUITE_P(
     WholeMemoryGatherTestParam().set_memory_type(WHOLEMEMORY_MT_CONTINUOUS),
     WholeMemoryGatherTestParam().set_memory_type(WHOLEMEMORY_MT_CHUNKED),
     WholeMemoryGatherTestParam().set_memory_type(WHOLEMEMORY_MT_DISTRIBUTED),
+    WholeMemoryGatherTestParam().set_memory_type(WHOLEMEMORY_MT_HIERARCHY),
     WholeMemoryGatherTestParam().set_memory_type(WHOLEMEMORY_MT_CONTINUOUS).set_indices_count(0),
     WholeMemoryGatherTestParam().set_memory_type(WHOLEMEMORY_MT_CHUNKED).set_indices_count(0),
     WholeMemoryGatherTestParam().set_memory_type(WHOLEMEMORY_MT_DISTRIBUTED).set_indices_count(0),
+    WholeMemoryGatherTestParam().set_memory_type(WHOLEMEMORY_MT_HIERARCHY).set_indices_count(0),
     WholeMemoryGatherTestParam()
       .set_memory_type(WHOLEMEMORY_MT_CONTINUOUS)
       .set_memory_location(WHOLEMEMORY_ML_HOST),
@@ -312,10 +314,18 @@ INSTANTIATE_TEST_SUITE_P(
     WholeMemoryGatherTestParam()
       .set_memory_type(WHOLEMEMORY_MT_DISTRIBUTED)
       .set_memory_location(WHOLEMEMORY_ML_HOST),
+    WholeMemoryGatherTestParam()
+      .set_memory_type(WHOLEMEMORY_MT_HIERARCHY)
+      .set_memory_location(WHOLEMEMORY_ML_HOST),
     WholeMemoryGatherTestParam().set_memory_type(WHOLEMEMORY_MT_CHUNKED).use_random_partition(),
     WholeMemoryGatherTestParam().set_memory_type(WHOLEMEMORY_MT_DISTRIBUTED).use_random_partition(),
+    WholeMemoryGatherTestParam().set_memory_type(WHOLEMEMORY_MT_HIERARCHY).use_random_partition(),
     WholeMemoryGatherTestParam()
       .set_memory_type(WHOLEMEMORY_MT_DISTRIBUTED)
+      .set_memory_location(WHOLEMEMORY_ML_HOST)
+      .use_random_partition(),
+    WholeMemoryGatherTestParam()
+      .set_memory_type(WHOLEMEMORY_MT_HIERARCHY)
       .set_memory_location(WHOLEMEMORY_ML_HOST)
       .use_random_partition(),
     WholeMemoryGatherTestParam()
@@ -353,18 +363,27 @@ INSTANTIATE_TEST_SUITE_P(
       .set_embedding_dim(11)
       .set_embedding_stride(12)
       .set_indices_count(100005),
+    WholeMemoryGatherTestParam()
+      .set_memory_type(WHOLEMEMORY_MT_HIERARCHY)
+      .set_embedding_dim(11)
+      .set_embedding_stride(12)
+      .set_indices_count(100005),
     WholeMemoryGatherTestParam().set_memory_type(WHOLEMEMORY_MT_CONTINUOUS).set_embedding_dim(128),
     WholeMemoryGatherTestParam().set_memory_type(WHOLEMEMORY_MT_CHUNKED).set_embedding_dim(128),
     WholeMemoryGatherTestParam().set_memory_type(WHOLEMEMORY_MT_DISTRIBUTED).set_embedding_dim(128),
+    WholeMemoryGatherTestParam().set_memory_type(WHOLEMEMORY_MT_HIERARCHY).set_embedding_dim(128),
     WholeMemoryGatherTestParam().set_memory_type(WHOLEMEMORY_MT_CONTINUOUS).set_embedding_dim(127),
     WholeMemoryGatherTestParam().set_memory_type(WHOLEMEMORY_MT_CHUNKED).set_embedding_dim(127),
     WholeMemoryGatherTestParam().set_memory_type(WHOLEMEMORY_MT_DISTRIBUTED).set_embedding_dim(127),
+    WholeMemoryGatherTestParam().set_memory_type(WHOLEMEMORY_MT_HIERARCHY).set_embedding_dim(127),
     WholeMemoryGatherTestParam().set_memory_type(WHOLEMEMORY_MT_CONTINUOUS).set_embedding_dim(129),
     WholeMemoryGatherTestParam().set_memory_type(WHOLEMEMORY_MT_CHUNKED).set_embedding_dim(129),
     WholeMemoryGatherTestParam().set_memory_type(WHOLEMEMORY_MT_DISTRIBUTED).set_embedding_dim(129),
+    WholeMemoryGatherTestParam().set_memory_type(WHOLEMEMORY_MT_HIERARCHY).set_embedding_dim(129),
     WholeMemoryGatherTestParam().set_memory_type(WHOLEMEMORY_MT_CONTINUOUS).set_embedding_dim(513),
     WholeMemoryGatherTestParam().set_memory_type(WHOLEMEMORY_MT_CHUNKED).set_embedding_dim(513),
     WholeMemoryGatherTestParam().set_memory_type(WHOLEMEMORY_MT_DISTRIBUTED).set_embedding_dim(513),
+    WholeMemoryGatherTestParam().set_memory_type(WHOLEMEMORY_MT_HIERARCHY).set_embedding_dim(513),
     WholeMemoryGatherTestParam()
       .set_memory_type(WHOLEMEMORY_MT_CONTINUOUS)
       .set_embedding_type(WHOLEMEMORY_DT_HALF),
@@ -382,6 +401,9 @@ INSTANTIATE_TEST_SUITE_P(
       .set_output_type(WHOLEMEMORY_DT_HALF),
     WholeMemoryGatherTestParam()
       .set_memory_type(WHOLEMEMORY_MT_DISTRIBUTED)
+      .set_output_type(WHOLEMEMORY_DT_HALF),
+    WholeMemoryGatherTestParam()
+      .set_memory_type(WHOLEMEMORY_MT_HIERARCHY)
       .set_output_type(WHOLEMEMORY_DT_HALF),
     WholeMemoryGatherTestParam()
       .set_memory_type(WHOLEMEMORY_MT_CONTINUOUS)
@@ -393,6 +415,10 @@ INSTANTIATE_TEST_SUITE_P(
       .set_output_type(WHOLEMEMORY_DT_HALF),
     WholeMemoryGatherTestParam()
       .set_memory_type(WHOLEMEMORY_MT_DISTRIBUTED)
+      .set_embedding_type(WHOLEMEMORY_DT_HALF)
+      .set_output_type(WHOLEMEMORY_DT_HALF),
+    WholeMemoryGatherTestParam()
+      .set_memory_type(WHOLEMEMORY_MT_HIERARCHY)
       .set_embedding_type(WHOLEMEMORY_DT_HALF)
       .set_output_type(WHOLEMEMORY_DT_HALF),
     WholeMemoryGatherTestParam()
@@ -403,6 +429,9 @@ INSTANTIATE_TEST_SUITE_P(
       .set_indices_type(WHOLEMEMORY_DT_INT64),
     WholeMemoryGatherTestParam()
       .set_memory_type(WHOLEMEMORY_MT_DISTRIBUTED)
+      .set_indices_type(WHOLEMEMORY_DT_INT64),
+    WholeMemoryGatherTestParam()
+      .set_memory_type(WHOLEMEMORY_MT_HIERARCHY)
       .set_indices_type(WHOLEMEMORY_DT_INT64),
     WholeMemoryGatherTestParam()
       .set_memory_type(WHOLEMEMORY_MT_CONTINUOUS)
@@ -411,9 +440,11 @@ INSTANTIATE_TEST_SUITE_P(
     WholeMemoryGatherTestParam()
       .set_memory_type(WHOLEMEMORY_MT_DISTRIBUTED)
       .set_embedding_stride(33),
+    WholeMemoryGatherTestParam().set_memory_type(WHOLEMEMORY_MT_HIERARCHY).set_embedding_stride(33),
     WholeMemoryGatherTestParam().set_memory_type(WHOLEMEMORY_MT_CONTINUOUS).set_output_stride(33),
     WholeMemoryGatherTestParam().set_memory_type(WHOLEMEMORY_MT_CHUNKED).set_output_stride(33),
     WholeMemoryGatherTestParam().set_memory_type(WHOLEMEMORY_MT_DISTRIBUTED).set_output_stride(33),
+    WholeMemoryGatherTestParam().set_memory_type(WHOLEMEMORY_MT_HIERARCHY).set_output_stride(33),
     WholeMemoryGatherTestParam()
       .set_memory_type(WHOLEMEMORY_MT_CONTINUOUS)
       .set_embedding_type(WHOLEMEMORY_DT_HALF)
@@ -424,6 +455,10 @@ INSTANTIATE_TEST_SUITE_P(
       .set_embedding_stride(33),
     WholeMemoryGatherTestParam()
       .set_memory_type(WHOLEMEMORY_MT_DISTRIBUTED)
+      .set_embedding_type(WHOLEMEMORY_DT_HALF)
+      .set_embedding_stride(33),
+    WholeMemoryGatherTestParam()
+      .set_memory_type(WHOLEMEMORY_MT_HIERARCHY)
       .set_embedding_type(WHOLEMEMORY_DT_HALF)
       .set_embedding_stride(33),
     WholeMemoryGatherTestParam().set_memory_type(WHOLEMEMORY_MT_DISTRIBUTED)

--- a/python/pylibwholegraph/pylibwholegraph/binding/wholememory_binding.pyx
+++ b/python/pylibwholegraph/pylibwholegraph/binding/wholememory_binding.pyx
@@ -131,6 +131,12 @@ cdef extern from "wholememory/wholememory.h":
     cdef wholememory_error_code_t wholememory_get_communicator(wholememory_comm_t * comm,
                                                                wholememory_handle_t wholememory_handle)
 
+    cdef wholememory_error_code_t wholememory_get_local_communicator(wholememory_comm_t * comm,
+                                                                     wholememory_handle_t wholememory_handle)
+
+    cdef wholememory_error_code_t wholememory_get_cross_communicator(wholememory_comm_t * comm,
+                                                                     wholememory_handle_t wholememory_handle)
+
     cdef wholememory_memory_type_t wholememory_get_memory_type(wholememory_handle_t wholememory_handle)
 
     cdef wholememory_memory_location_t wholememory_get_memory_location(wholememory_handle_t wholememory_handle)
@@ -1342,6 +1348,16 @@ cdef class PyWholeMemoryHandle:
     def get_communicator(self):
         py_comm = PyWholeMemoryComm()
         check_wholememory_error_code(wholememory_get_communicator(&py_comm.comm_id, self.wholememory_handle))
+        return py_comm
+
+    def get_local_communicator(self):
+        py_comm = PyWholeMemoryComm()
+        check_wholememory_error_code(wholememory_get_local_communicator(&py_comm.comm_id, self.wholememory_handle))
+        return py_comm
+
+    def get_cross_communicator(self):
+        py_comm = PyWholeMemoryComm()
+        check_wholememory_error_code(wholememory_get_cross_communicator(&py_comm.comm_id, self.wholememory_handle))
         return py_comm
 
     def get_memory_type(self):

--- a/python/pylibwholegraph/pylibwholegraph/binding/wholememory_binding.pyx
+++ b/python/pylibwholegraph/pylibwholegraph/binding/wholememory_binding.pyx
@@ -61,6 +61,7 @@ cdef extern from "wholememory/wholememory.h":
         WHOLEMEMORY_MT_CONTINUOUS           "WHOLEMEMORY_MT_CONTINUOUS"
         WHOLEMEMORY_MT_CHUNKED              "WHOLEMEMORY_MT_CHUNKED"
         WHOLEMEMORY_MT_DISTRIBUTED          "WHOLEMEMORY_MT_DISTRIBUTED"
+        WHOLEMEMORY_MT_HIERARCHY            "WHOLEMEMORY_MT_HIERARCHY"
 
     ctypedef enum wholememory_memory_location_t:
         WHOLEMEMORY_ML_NONE                 "WHOLEMEMORY_ML_NONE"
@@ -226,6 +227,7 @@ cpdef enum WholeMemoryMemoryType:
     MtContinuous = WHOLEMEMORY_MT_CONTINUOUS
     MtChunked = WHOLEMEMORY_MT_CHUNKED
     MtDistributed = WHOLEMEMORY_MT_DISTRIBUTED
+    MtHierarchy = WHOLEMEMORY_MT_HIERARCHY
 
 cpdef enum WholeMemoryMemoryLocation:
     MlNone = WHOLEMEMORY_ML_NONE

--- a/python/pylibwholegraph/pylibwholegraph/test_utils/test_comm.py
+++ b/python/pylibwholegraph/pylibwholegraph/test_utils/test_comm.py
@@ -185,6 +185,8 @@ def int_to_wholememory_type(value: int):
         return wmb.WholeMemoryMemoryType.MtChunked
     if value == 2:
         return wmb.WholeMemoryMemoryType.MtDistributed
+    if value == 3:
+        return wmb.WholeMemoryMemoryType.MtHierarchy
     else:
         raise ValueError("invalid int_to_wholememory_type value")
 

--- a/python/pylibwholegraph/pylibwholegraph/torch/common_options.py
+++ b/python/pylibwholegraph/pylibwholegraph/torch/common_options.py
@@ -33,7 +33,7 @@ def add_training_options(argparser: ArgumentParser):
         "--embedding-memory-type",
         dest="embedding_memory_type",
         default="chunked",
-        help="Embedding memory type, should be: continuous, chunked or distributed",
+        help="Embedding memory type, should be: continuous, chunked, distributed, hierarchy",
     )
     argparser.add_argument(
         "--cache-type",

--- a/python/pylibwholegraph/pylibwholegraph/torch/embedding.py
+++ b/python/pylibwholegraph/pylibwholegraph/torch/embedding.py
@@ -145,6 +145,7 @@ def create_builtin_cache_policy(
         embedding_memory_type != "continuous"
         and embedding_memory_type != "chunked"
         and embedding_memory_type != "distributed"
+        and embedding_memory_type != "hierarchy"
     ):
         raise ValueError(f"embedding_memory_type={embedding_memory_type} is not valid")
 
@@ -425,6 +426,16 @@ def create_embedding(
     if embedding_entry_partition is not None and round_robin_size != 0:
         print("round_robin_size is ignored because embedding_entry_partition is specified")
         round_robin_size = 0
+    if memory_type == 'hierarchy': # todo: modified
+        comm_backend = comm.distributed_backend
+        if comm_backend == 'nvshmem':
+            raise AssertionError
+        ("Hierarchy embedding is not supported yet when using NVSHMEM.")
+        if cache_policy is not None:
+            raise AssertionError
+        ("Hierarchy embedding is not supported yet when using cache.")
+        comm_backend = 'nccl'
+
     wm_embedding = WholeMemoryEmbedding(
         wmb.create_embedding(
             tensor_desc,

--- a/python/pylibwholegraph/pylibwholegraph/torch/embedding.py
+++ b/python/pylibwholegraph/pylibwholegraph/torch/embedding.py
@@ -426,7 +426,7 @@ def create_embedding(
     if embedding_entry_partition is not None and round_robin_size != 0:
         print("round_robin_size is ignored because embedding_entry_partition is specified")
         round_robin_size = 0
-    if memory_type == 'hierarchy': # todo: modified
+    if memory_type == 'hierarchy':  # todo: modified
         comm_backend = comm.distributed_backend
         if comm_backend == 'nvshmem':
             raise AssertionError

--- a/python/pylibwholegraph/pylibwholegraph/torch/utils.py
+++ b/python/pylibwholegraph/pylibwholegraph/torch/utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2023, NVIDIA CORPORATION.
+# Copyright (c) 2019-2024, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -92,9 +92,11 @@ def str_to_wmb_wholememory_memory_type(str_wmb_type: str):
         return wmb.WholeMemoryMemoryType.MtChunked
     elif str_wmb_type == "distributed":
         return wmb.WholeMemoryMemoryType.MtDistributed
+    elif str_wmb_type == "hierarchy":
+        return wmb.WholeMemoryMemoryType.MtHierarchy
     else:
         raise ValueError(
-            "WholeMemory type %s not supported, should be (continuous, chunked, distributed)"
+            "WholeMemory type %s not supported, should be (continuous, chunked, distributed, hierarchy)"
             % (str_wmb_type,)
         )
 


### PR DESCRIPTION
This PR adds a new memory type called Hierarchy, which exploits power-law degree distribution in graph to reduce inter-node communication.
1. Hierarchy WholeMemory has the same storage pattern as Distributed WholeMemory and only optimizes the gather function.
2. Hierarchy WholeMemory can achieve 1.5x-2.0x speedup in multi-node gather, compared with Distributed. 
3. For intra-node host memory location, Hierarchy can still achieve 1.5x-2.0x speedup.