### PR TITLE
make conda installations in CI stricter

### DIFF
--- a/ci/build_docs.sh
+++ b/ci/build_docs.sh
@@ -6,8 +6,7 @@ set -euo pipefail
 rapids-logger "Create test conda environment"
 . /opt/conda/etc/profile.d/conda.sh
 
-RAPIDS_VERSION_MAJOR_MINOR="$(rapids-version-major-minor)"
-export RAPIDS_VERSION_NUMBER="${RAPIDS_VERSION_MAJOR_MINOR}"
+RAPIDS_VERSION="$(rapids-version)"
 
 rapids-dependency-file-generator \
   --output conda \
@@ -29,7 +28,7 @@ export RAPIDS_DOCS_DIR="$(mktemp -d)"
 
 rapids-mamba-retry install \
   --channel "${CPP_CHANNEL}" \
-  "libwholegraph=${RAPIDS_VERSION_MAJOR_MINOR}"
+  "libwholegraph=${RAPIDS_VERSION}"
 
 rapids-logger "Build Doxygen docs"
 pushd cpp
@@ -40,4 +39,4 @@ popd
 
 rapids-logger "Output temp dir: ${RAPIDS_DOCS_DIR}"
 
-rapids-upload-docs
+RAPIDS_VERSION_NUMBER="$(rapids-verion-major-minor)" rapids-upload-docs

--- a/ci/build_docs.sh
+++ b/ci/build_docs.sh
@@ -6,6 +6,9 @@ set -euo pipefail
 rapids-logger "Create test conda environment"
 . /opt/conda/etc/profile.d/conda.sh
 
+RAPIDS_VERSION_MAJOR_MINOR="$(rapids-version-major-minor)"
+export RAPIDS_VERSION_NUMBER="${RAPIDS_VERSION_MAJOR_MINOR}"
+
 rapids-dependency-file-generator \
   --output conda \
   --file-key docs \
@@ -22,12 +25,11 @@ rapids-print-env
 rapids-logger "Downloading artifacts from previous jobs"
 
 CPP_CHANNEL=$(rapids-download-conda-from-s3 cpp)
-export RAPIDS_VERSION_NUMBER="24.12"
 export RAPIDS_DOCS_DIR="$(mktemp -d)"
 
 rapids-mamba-retry install \
   --channel "${CPP_CHANNEL}" \
-  libwholegraph
+  "libwholegraph=${RAPIDS_VERSION_MAJOR_MINOR}"
 
 rapids-logger "Build Doxygen docs"
 pushd cpp

--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -13,8 +13,6 @@ export CMAKE_GENERATOR=Ninja
 
 rapids-print-env
 
-PACKAGES="libwholegraph"
-
 CPP_CHANNEL=$(rapids-download-conda-from-s3 cpp)
 
 rapids-generate-version > ./VERSION

--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -81,4 +81,3 @@ for FILE in .github/workflows/*.yaml; do
   sed_runner "/shared-workflows/ s/@.*/@branch-${NEXT_SHORT_TAG}/g" "${FILE}"
 
 done
-sed_runner "s/RAPIDS_VERSION_NUMBER=\".*/RAPIDS_VERSION_NUMBER=\"${NEXT_SHORT_TAG}\"/g" ci/build_docs.sh

--- a/ci/test_cpp.sh
+++ b/ci/test_cpp.sh
@@ -8,6 +8,8 @@ cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../
 
 . /opt/conda/etc/profile.d/conda.sh
 
+RAPIDS_VERSION_MAJOR_MINOR="$(rapids-version-major-minor)"
+
 rapids-logger "Generate C++ testing dependencies"
 rapids-dependency-file-generator \
   --output conda \
@@ -27,11 +29,10 @@ mkdir -p "${RAPIDS_TESTS_DIR}"
 
 rapids-print-env
 
-PACKAGES="libwholegraph libwholegraph-tests"
-
 rapids-mamba-retry install \
   --channel "${CPP_CHANNEL}" \
-  "${PACKAGES}"
+  "libwholegraph=${RAPIDS_MAJOR_MINOR_VERSION}" \
+  "libwholegraph-tests=${RAPIDS_MAJOR_MINOR_VERSION}"
 
 rapids-logger "Check GPU usage"
 nvidia-smi

--- a/ci/test_cpp.sh
+++ b/ci/test_cpp.sh
@@ -31,8 +31,8 @@ rapids-print-env
 
 rapids-mamba-retry install \
   --channel "${CPP_CHANNEL}" \
-  "libwholegraph=${RAPIDS_MAJOR_MINOR_VERSION}" \
-  "libwholegraph-tests=${RAPIDS_MAJOR_MINOR_VERSION}"
+  "libwholegraph=${RAPIDS_VERSION_MAJOR_MINOR}" \
+  "libwholegraph-tests=${RAPIDS_VERSION_MAJOR_MINOR}"
 
 rapids-logger "Check GPU usage"
 nvidia-smi

--- a/ci/test_cpp.sh
+++ b/ci/test_cpp.sh
@@ -8,7 +8,7 @@ cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../
 
 . /opt/conda/etc/profile.d/conda.sh
 
-RAPIDS_VERSION_MAJOR_MINOR="$(rapids-version-major-minor)"
+RAPIDS_VERSION="$(rapids-version)"
 
 rapids-logger "Generate C++ testing dependencies"
 rapids-dependency-file-generator \
@@ -31,8 +31,8 @@ rapids-print-env
 
 rapids-mamba-retry install \
   --channel "${CPP_CHANNEL}" \
-  "libwholegraph=${RAPIDS_VERSION_MAJOR_MINOR}" \
-  "libwholegraph-tests=${RAPIDS_VERSION_MAJOR_MINOR}"
+  "libwholegraph=${RAPIDS_VERSION}" \
+  "libwholegraph-tests=${RAPIDS_VERSION}"
 
 rapids-logger "Check GPU usage"
 nvidia-smi

--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -8,6 +8,8 @@ cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../
 
 . /opt/conda/etc/profile.d/conda.sh
 
+RAPIDS_VERSION_MAJOR_MINOR="$(rapids-version-major-minor)"
+
 ARCH=$(arch)
 EXITCODE=0
 
@@ -44,13 +46,11 @@ mkdir -p "${RAPIDS_TESTS_DIR}" "${RAPIDS_COVERAGE_DIR}"
 
 rapids-print-env
 
-PACKAGES="pylibwholegraph"
-
 rapids-mamba-retry install \
   --channel "${CPP_CHANNEL}" \
   --channel "${PYTHON_CHANNEL}" \
   'mkl<2024.1.0' \
-  "${PACKAGES}"
+  "pylibwholegraph=${RAPIDS_MAJOR_MINOR_VERSION}"
 
 rapids-logger "Check GPU usage"
 nvidia-smi

--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -50,7 +50,7 @@ rapids-mamba-retry install \
   --channel "${CPP_CHANNEL}" \
   --channel "${PYTHON_CHANNEL}" \
   'mkl<2024.1.0' \
-  "pylibwholegraph=${RAPIDS_MAJOR_MINOR_VERSION}"
+  "pylibwholegraph=${RAPIDS_VERSION_MAJOR_MINOR}"
 
 rapids-logger "Check GPU usage"
 nvidia-smi

--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -8,7 +8,7 @@ cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../
 
 . /opt/conda/etc/profile.d/conda.sh
 
-RAPIDS_VERSION_MAJOR_MINOR="$(rapids-version-major-minor)"
+RAPIDS_VERSION="$(rapids-version)"
 
 ARCH=$(arch)
 EXITCODE=0
@@ -50,7 +50,7 @@ rapids-mamba-retry install \
   --channel "${CPP_CHANNEL}" \
   --channel "${PYTHON_CHANNEL}" \
   'mkl<2024.1.0' \
-  "pylibwholegraph=${RAPIDS_VERSION_MAJOR_MINOR}"
+  "pylibwholegraph=${RAPIDS_VERSION}"
 
 rapids-logger "Check GPU usage"
 nvidia-smi

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2023-2024, NVIDIA CORPORATION.
+# Copyright (c) 2023, NVIDIA CORPORATION.
 
 set -e          # abort the script on error
 set -o pipefail # piped commands propagate their error
@@ -7,9 +7,11 @@ set -E          # ERR traps are inherited by subcommands
 
 mkdir -p ./dist
 RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen ${RAPIDS_CUDA_VERSION})"
-RAPIDS_PY_WHEEL_NAME="pylibwholegraph_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-s3 python ./dist
+RAPIDS_PY_WHEEL_NAME="pylibwholegraph_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-s3 ./dist
 
-# determine pytorch source
+# echo to expand wildcard before adding `[extra]` requires for pip
+python -m pip install $(echo ./dist/pylibwholegraph*.whl)
+
 PKG_CUDA_VER="$(echo ${CUDA_VERSION} | cut -d '.' -f1,2 | tr -d '.')"
 PKG_CUDA_VER_MAJOR=${PKG_CUDA_VER:0:2}
 if [[ "${PKG_CUDA_VER_MAJOR}" == "12" ]]; then
@@ -17,22 +19,13 @@ if [[ "${PKG_CUDA_VER_MAJOR}" == "12" ]]; then
 else
   INDEX_URL="https://download.pytorch.org/whl/cu${PKG_CUDA_VER}"
 fi
-
-# echo to expand wildcard before adding `[extra]` requires for pip
-python -m pip install \
-    -v \
-    --extra-index-url "${INDEX_URL}" \
-    "$(echo ./dist/pylibwholegraph*.whl)" \
-    numpy \
-    pytest \
-    pytest-forked \
-    'torch>=2.0.0a0'
-
 RAPIDS_TESTS_DIR=${RAPIDS_TESTS_DIR:-"${PWD}/test-results"}
 RAPIDS_COVERAGE_DIR=${RAPIDS_COVERAGE_DIR:-"${PWD}/coverage-results"}
 mkdir -p "${RAPIDS_TESTS_DIR}" "${RAPIDS_COVERAGE_DIR}"
 
 rapids-logger "Installing PyTorch"
+rapids-retry python -m pip install --pre torch --index-url ${INDEX_URL}
+rapids-retry python -m pip install pytest pytest-forked numpy
 rapids-logger "pytest pylibwholegraph"
 cd python/pylibwholegraph/pylibwholegraph/tests
 python -m pytest \

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2024, NVIDIA CORPORATION.
 
 set -e          # abort the script on error
 set -o pipefail # piped commands propagate their error
@@ -7,11 +7,9 @@ set -E          # ERR traps are inherited by subcommands
 
 mkdir -p ./dist
 RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen ${RAPIDS_CUDA_VERSION})"
-RAPIDS_PY_WHEEL_NAME="pylibwholegraph_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-s3 ./dist
+RAPIDS_PY_WHEEL_NAME="pylibwholegraph_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-s3 python ./dist
 
-# echo to expand wildcard before adding `[extra]` requires for pip
-python -m pip install $(echo ./dist/pylibwholegraph*.whl)
-
+# determine pytorch source
 PKG_CUDA_VER="$(echo ${CUDA_VERSION} | cut -d '.' -f1,2 | tr -d '.')"
 PKG_CUDA_VER_MAJOR=${PKG_CUDA_VER:0:2}
 if [[ "${PKG_CUDA_VER_MAJOR}" == "12" ]]; then
@@ -19,13 +17,22 @@ if [[ "${PKG_CUDA_VER_MAJOR}" == "12" ]]; then
 else
   INDEX_URL="https://download.pytorch.org/whl/cu${PKG_CUDA_VER}"
 fi
+
+# echo to expand wildcard before adding `[extra]` requires for pip
+python -m pip install \
+    -v \
+    --extra-index-url "${INDEX_URL}" \
+    "$(echo ./dist/pylibwholegraph*.whl)" \
+    numpy \
+    pytest \
+    pytest-forked \
+    'torch>=2.0.0a0'
+
 RAPIDS_TESTS_DIR=${RAPIDS_TESTS_DIR:-"${PWD}/test-results"}
 RAPIDS_COVERAGE_DIR=${RAPIDS_COVERAGE_DIR:-"${PWD}/coverage-results"}
 mkdir -p "${RAPIDS_TESTS_DIR}" "${RAPIDS_COVERAGE_DIR}"
 
 rapids-logger "Installing PyTorch"
-rapids-retry python -m pip install --pre torch --index-url ${INDEX_URL}
-rapids-retry python -m pip install pytest pytest-forked numpy
 rapids-logger "pytest pylibwholegraph"
 cd python/pylibwholegraph/pylibwholegraph/tests
 python -m pytest \


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/106

Proposes specifying the RAPIDS version in `conda install` calls in CI that install CI artifacts, to reduce the risk of CI jobs picking up artifacts from other releases.