### PR TITLE
[Bugfix] Dynamic load NVML symbols for better compatibility 

### DIFF
--- a/cpp/src/nvml_wrap.cpp
+++ b/cpp/src/nvml_wrap.cpp
@@ -1,0 +1,74 @@
+// Copyright (c) 2020-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <dlfcn.h>
+#include <stdio.h>
+#include <mutex>
+#include "nvml_wrap.h"
+
+namespace {
+
+void* nvml_handle = nullptr;
+std::mutex nvml_mutex;
+bool nvml_loaded = false;
+
+bool LoadNvmlLibrary() {
+  nvml_handle = dlopen("libnvidia-ml.so.1", RTLD_NOW);
+  if (!nvml_handle) {
+    nvml_handle = dlopen("libnvidia-ml.so", RTLD_NOW);
+    if (!nvml_handle) {
+      fprintf(stderr, "Failed to load NVML library: %s\n", dlerror());
+      return false;
+    }
+  }
+  return true;
+}
+
+template <typename T>
+T LoadNvmlSymbol(const char* name) {
+  void* symbol = dlsym(nvml_handle, name);
+  if (!symbol) {
+    fprintf(stderr, "Failed to load NVML symbol %s: %s\n", name, dlerror());
+  }
+  return reinterpret_cast<T>(symbol);
+}
+
+}  // namespace
+
+// Global function pointers
+nvmlDeviceGetHandleByIndexFunc nvmlDeviceGetHandleByIndexPtr = nullptr;
+nvmlDeviceGetGpuFabricInfoFunc nvmlDeviceGetGpuFabricInfoPtr = nullptr;
+
+// Ensure NVML is loaded and symbols are initialized
+bool NvmlFabricSymbolLoaded() {
+  std::lock_guard<std::mutex> lock(nvml_mutex);
+  if (nvml_loaded) {
+    return true; // Already loaded
+  }
+
+  if (LoadNvmlLibrary()) {
+    nvmlDeviceGetHandleByIndexPtr =
+      LoadNvmlSymbol<nvmlDeviceGetHandleByIndexFunc>("nvmlDeviceGetHandleByIndex");
+    nvmlDeviceGetGpuFabricInfoPtr =
+      LoadNvmlSymbol<nvmlDeviceGetGpuFabricInfoFunc>("nvmlDeviceGetGpuFabricInfo");
+
+    if (!nvmlDeviceGetHandleByIndexPtr || !nvmlDeviceGetGpuFabricInfoPtr) {
+      dlclose(nvml_handle);
+      nvml_handle = nullptr;
+    } else {
+      nvml_loaded = true;
+    }
+  }
+  return nvml_loaded;
+}

--- a/cpp/src/nvml_wrap.cpp
+++ b/cpp/src/nvml_wrap.cpp
@@ -12,10 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <dlfcn.h>
-#include <stdio.h>
-#include <mutex>
 #include "nvml_wrap.h"
+
+#if CUDA_VERSION >= 12030
+#include <dlfcn.h>
+#include <mutex>
+#include <stdio.h>
 
 namespace {
 
@@ -23,7 +25,8 @@ void* nvml_handle = nullptr;
 std::mutex nvml_mutex;
 bool nvml_loaded = false;
 
-bool LoadNvmlLibrary() {
+bool LoadNvmlLibrary()
+{
   nvml_handle = dlopen("libnvidia-ml.so.1", RTLD_NOW);
   if (!nvml_handle) {
     nvml_handle = dlopen("libnvidia-ml.so", RTLD_NOW);
@@ -36,11 +39,10 @@ bool LoadNvmlLibrary() {
 }
 
 template <typename T>
-T LoadNvmlSymbol(const char* name) {
+T LoadNvmlSymbol(const char* name)
+{
   void* symbol = dlsym(nvml_handle, name);
-  if (!symbol) {
-    return nullptr;
-  }
+  if (!symbol) { return nullptr; }
   return reinterpret_cast<T>(symbol);
 }
 
@@ -51,10 +53,11 @@ nvmlDeviceGetHandleByIndexFunc nvmlDeviceGetHandleByIndexPtr = nullptr;
 nvmlDeviceGetGpuFabricInfoFunc nvmlDeviceGetGpuFabricInfoPtr = nullptr;
 
 // Ensure NVML is loaded and symbols are initialized
-bool NvmlFabricSymbolLoaded() {
+bool NvmlFabricSymbolLoaded()
+{
   std::lock_guard<std::mutex> lock(nvml_mutex);
   if (nvml_loaded) {
-    return true; // Already loaded
+    return true;  // Already loaded
   }
 
   if (LoadNvmlLibrary()) {
@@ -72,3 +75,4 @@ bool NvmlFabricSymbolLoaded() {
   }
   return nvml_loaded;
 }
+#endif

--- a/cpp/src/nvml_wrap.cpp
+++ b/cpp/src/nvml_wrap.cpp
@@ -39,7 +39,7 @@ template <typename T>
 T LoadNvmlSymbol(const char* name) {
   void* symbol = dlsym(nvml_handle, name);
   if (!symbol) {
-    fprintf(stderr, "Failed to load NVML symbol %s: %s\n", name, dlerror());
+    return nullptr;
   }
   return reinterpret_cast<T>(symbol);
 }

--- a/cpp/src/nvml_wrap.h
+++ b/cpp/src/nvml_wrap.h
@@ -1,0 +1,26 @@
+// Copyright (c) 2020-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <nvml.h>
+
+
+bool NvmlFabricSymbolLoaded();
+
+typedef nvmlReturn_t (*nvmlDeviceGetHandleByIndexFunc)(unsigned int, nvmlDevice_t*);
+typedef nvmlReturn_t (*nvmlDeviceGetGpuFabricInfoFunc)(nvmlDevice_t, nvmlGpuFabricInfo_t*);
+
+extern nvmlDeviceGetHandleByIndexFunc nvmlDeviceGetHandleByIndexPtr;
+extern nvmlDeviceGetGpuFabricInfoFunc nvmlDeviceGetGpuFabricInfoPtr;

--- a/cpp/src/nvml_wrap.h
+++ b/cpp/src/nvml_wrap.h
@@ -13,9 +13,10 @@
 // limitations under the License.
 
 #pragma once
+#include <cuda.h>
 
+#if CUDA_VERSION >= 12030
 #include <nvml.h>
-
 
 bool NvmlFabricSymbolLoaded();
 
@@ -24,3 +25,4 @@ typedef nvmlReturn_t (*nvmlDeviceGetGpuFabricInfoFunc)(nvmlDevice_t, nvmlGpuFabr
 
 extern nvmlDeviceGetHandleByIndexFunc nvmlDeviceGetHandleByIndexPtr;
 extern nvmlDeviceGetGpuFabricInfoFunc nvmlDeviceGetGpuFabricInfoPtr;
+#endif

--- a/cpp/src/wholememory/communicator.cpp
+++ b/cpp/src/wholememory/communicator.cpp
@@ -535,7 +535,7 @@ void exchange_rank_info(wholememory_comm_t wm_comm)
   wm_comm->clique_info.is_in_clique = 0;
 
 #if CUDA_VERSION >= 12030
-  if(nvmlFabricSymbolLoaded) {
+  if (nvmlFabricSymbolLoaded) {
     memset(&ri.fabric_info, 0, sizeof(ri.fabric_info));
     WHOLEMEMORY_CHECK_NOTHROW(GetGpuFabricInfo(wm_comm->dev_id, &ri.fabric_info) ==
                               WHOLEMEMORY_SUCCESS);
@@ -548,7 +548,9 @@ void exchange_rank_info(wholememory_comm_t wm_comm)
       wm_comm->clique_info.is_in_clique = 1;
     }
   } else {
-    WHOLEMEMORY_WARN("Some required NVML symbols are missing, likely due to an outdated GPU display driver. MNNVL support will be disabled.");
+    WHOLEMEMORY_WARN(
+      "Some required NVML symbols are missing, likely due to an outdated GPU display driver. MNNVL "
+      "support will be disabled.");
   }
 
 #endif
@@ -578,30 +580,32 @@ void exchange_rank_info(wholememory_comm_t wm_comm)
     }
 
 #if CUDA_VERSION >= 12030
-  if(nvmlFabricSymbolLoaded) {
-    if ((memcmp(ri.fabric_info.clusterUuid,
-                p_rank_info.get()[r].fabric_info.clusterUuid,
-                NVML_GPU_FABRIC_UUID_LEN) == 0) &&
-        (ri.fabric_info.cliqueId == p_rank_info.get()[r].fabric_info.cliqueId)) {
-      if (r == wm_comm->world_rank) {
-        wm_comm->clique_info.clique_rank = wm_comm->clique_info.clique_rank_num;
+    if (nvmlFabricSymbolLoaded) {
+      if ((memcmp(ri.fabric_info.clusterUuid,
+                  p_rank_info.get()[r].fabric_info.clusterUuid,
+                  NVML_GPU_FABRIC_UUID_LEN) == 0) &&
+          (ri.fabric_info.cliqueId == p_rank_info.get()[r].fabric_info.cliqueId)) {
+        if (r == wm_comm->world_rank) {
+          wm_comm->clique_info.clique_rank = wm_comm->clique_info.clique_rank_num;
+        }
+        if (wm_comm->clique_info.clique_rank_num == 0) {
+          wm_comm->clique_info.clique_first_rank = r;
+        }
+        wm_comm->clique_info.clique_rank_num++;
       }
-      if (wm_comm->clique_info.clique_rank_num == 0) { wm_comm->clique_info.clique_first_rank = r; }
-      wm_comm->clique_info.clique_rank_num++;
+      clique_uuids.insert(
+        std::string(reinterpret_cast<const char*>(p_rank_info.get()[r].fabric_info.clusterUuid),
+                    NVML_GPU_FABRIC_UUID_LEN));
     }
-    clique_uuids.insert(
-      std::string(reinterpret_cast<const char*>(p_rank_info.get()[r].fabric_info.clusterUuid),
-                  NVML_GPU_FABRIC_UUID_LEN));
-  }
 #endif
   }
 
 #if CUDA_VERSION >= 12030
-  if(nvmlFabricSymbolLoaded) {
+  if (nvmlFabricSymbolLoaded) {
     wm_comm->clique_info.clique_num = clique_uuids.size();
 
     std::string uuid = std::string(reinterpret_cast<const char*>(ri.fabric_info.clusterUuid),
-                                  NVML_GPU_FABRIC_UUID_LEN);
+                                   NVML_GPU_FABRIC_UUID_LEN);
     int id           = 0;
     for (auto clique_uuid : clique_uuids) {
       if (clique_uuid == uuid) { wm_comm->clique_info.clique_id = id; }

--- a/cpp/src/wholememory/communicator.cpp
+++ b/cpp/src/wholememory/communicator.cpp
@@ -497,6 +497,7 @@ void get_host_info(host_info* phi)
 bool comm_support_mnnvl(wholememory_comm_t wm_comm, const std::unique_ptr<rank_info[]>& p_rank_info)
 {
 #if CUDA_VERSION >= 12030
+  if (!nvmlFabricSymbolLoaded) return 0;
   int flag = 0;
   CUdevice currentDev;
   WM_CU_CHECK_NO_THROW(cuDeviceGet(&currentDev, wm_comm->dev_id));
@@ -534,16 +535,20 @@ void exchange_rank_info(wholememory_comm_t wm_comm)
   wm_comm->clique_info.is_in_clique = 0;
 
 #if CUDA_VERSION >= 12030
-  memset(&ri.fabric_info, 0, sizeof(ri.fabric_info));
-  WHOLEMEMORY_CHECK_NOTHROW(GetGpuFabricInfo(wm_comm->dev_id, &ri.fabric_info) ==
-                            WHOLEMEMORY_SUCCESS);
+  if(nvmlFabricSymbolLoaded) {
+    memset(&ri.fabric_info, 0, sizeof(ri.fabric_info));
+    WHOLEMEMORY_CHECK_NOTHROW(GetGpuFabricInfo(wm_comm->dev_id, &ri.fabric_info) ==
+                              WHOLEMEMORY_SUCCESS);
 
-  //    // A zero UUID means we don't have MNNVL fabric info
-  if (((((long*)ri.fabric_info.clusterUuid)[0] | ((long*)ri.fabric_info.clusterUuid)[1]) == 0)) {
-    wm_comm->clique_info.is_in_clique = 0;
+    //    // A zero UUID means we don't have MNNVL fabric info
+    if (((((long*)ri.fabric_info.clusterUuid)[0] | ((long*)ri.fabric_info.clusterUuid)[1]) == 0)) {
+      wm_comm->clique_info.is_in_clique = 0;
 
+    } else {
+      wm_comm->clique_info.is_in_clique = 1;
+    }
   } else {
-    wm_comm->clique_info.is_in_clique = 1;
+    WHOLEMEMORY_WARN("Some required NVML symbols are missing, likely due to an outdated GPU display driver. MNNVL support will be disabled.");
   }
 
 #endif
@@ -573,7 +578,7 @@ void exchange_rank_info(wholememory_comm_t wm_comm)
     }
 
 #if CUDA_VERSION >= 12030
-
+  if(nvmlFabricSymbolLoaded) {
     if ((memcmp(ri.fabric_info.clusterUuid,
                 p_rank_info.get()[r].fabric_info.clusterUuid,
                 NVML_GPU_FABRIC_UUID_LEN) == 0) &&
@@ -587,24 +592,25 @@ void exchange_rank_info(wholememory_comm_t wm_comm)
     clique_uuids.insert(
       std::string(reinterpret_cast<const char*>(p_rank_info.get()[r].fabric_info.clusterUuid),
                   NVML_GPU_FABRIC_UUID_LEN));
-
+  }
 #endif
   }
 
 #if CUDA_VERSION >= 12030
-  wm_comm->clique_info.clique_num = clique_uuids.size();
+  if(nvmlFabricSymbolLoaded) {
+    wm_comm->clique_info.clique_num = clique_uuids.size();
 
-  std::string uuid = std::string(reinterpret_cast<const char*>(ri.fabric_info.clusterUuid),
-                                 NVML_GPU_FABRIC_UUID_LEN);
-  int id           = 0;
-  for (auto clique_uuid : clique_uuids) {
-    if (clique_uuid == uuid) { wm_comm->clique_info.clique_id = id; }
-    id++;
+    std::string uuid = std::string(reinterpret_cast<const char*>(ri.fabric_info.clusterUuid),
+                                  NVML_GPU_FABRIC_UUID_LEN);
+    int id           = 0;
+    for (auto clique_uuid : clique_uuids) {
+      if (clique_uuid == uuid) { wm_comm->clique_info.clique_id = id; }
+      id++;
+    }
+
+    wm_comm->support_mnnvl = (comm_support_mnnvl(wm_comm, p_rank_info)) &&
+                             (wm_comm->clique_info.clique_rank_num == wm_comm->world_size);
   }
-
-  wm_comm->support_mnnvl = (comm_support_mnnvl(wm_comm, p_rank_info)) &&
-                           (wm_comm->clique_info.clique_rank_num == wm_comm->world_size);
-
 #endif
 }
 

--- a/cpp/src/wholememory/system_info.hpp
+++ b/cpp/src/wholememory/system_info.hpp
@@ -18,8 +18,8 @@
 #include "wholememory/wholememory.h"
 
 #if CUDA_VERSION >= 12030
-#include <nvml.h>
 #include "nvml_wrap.h"
+#include <nvml.h>
 #endif
 bool DevAttrPagebleMemoryAccess();
 
@@ -41,6 +41,6 @@ namespace wholememory {
 
 inline bool nvmlFabricSymbolLoaded = NvmlFabricSymbolLoaded();
 wholememory_error_code_t GetGpuFabricInfo(int dev, nvmlGpuFabricInfo_t* gpuFabricInfo);
-}
+}  // namespace wholememory
 
 #endif

--- a/cpp/src/wholememory/system_info.hpp
+++ b/cpp/src/wholememory/system_info.hpp
@@ -19,6 +19,7 @@
 
 #if CUDA_VERSION >= 12030
 #include <nvml.h>
+#include "nvml_wrap.h"
 #endif
 bool DevAttrPagebleMemoryAccess();
 
@@ -37,6 +38,8 @@ bool SupportEGM();
 // bool SupportMNNVLForEGM();
 #if CUDA_VERSION >= 12030
 namespace wholememory {
+
+inline bool nvmlFabricSymbolLoaded = NvmlFabricSymbolLoaded();
 wholememory_error_code_t GetGpuFabricInfo(int dev, nvmlGpuFabricInfo_t* gpuFabricInfo);
 }
 


### PR DESCRIPTION
[File PR here for the record]
Dynamically load NVML symbols for querying GPU fabric info to address incompatibility issues with outdated display drivers.